### PR TITLE
change!: rename package to `vitepress-openapi`

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,5 +1,5 @@
 name: "🐛 Bug Report"
-description: Report a bug found while using the theme.
+description: Report a bug found while using vitepress-openapi.
 labels: ["Type: Bug", "Status: Triage"]
 body:
   - type: textarea
@@ -20,7 +20,7 @@ body:
     id: reproduction
     attributes:
       label: Reproduction
-      description: Please provide a link via [vitepress-theme-openapi-starter StackBlitz](https://stackblitz.com/fork/github/enzonotario/vitepress-theme-openapi-starter?file=public/openapi.json) or a link to a repo that can reproduce the problem you ran into. A [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) is required ([Why?](https://antfu.me/posts/why-reproductions-are-required)). If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "needs reproduction" label.
+      description: Please provide a link via [vitepress-openapi-starter StackBlitz](https://stackblitz.com/fork/github/enzonotario/vitepress-openapi-starter?file=public/openapi.json) or a link to a repo that can reproduce the problem you ran into. A [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) is required ([Why?](https://antfu.me/posts/why-reproductions-are-required)). If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "needs reproduction" label.
       placeholder: Reproduction URL
   - type: textarea
     id: reproduction-steps

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,5 +1,5 @@
 name: "✨ Feature Request"
-description: Suggest a feature or enhancement to the theme.
+description: Suggest a feature or enhancement to vitepress-openapi.
 labels: ["Type: Idea"]
 body:
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Generate VitePress API Documentation from OpenAPI Specification.
 
 ## Documentation
 
-To get started, check out the [documentation](https://vitepress-theme-openapi.vercel.app/).
+To get started, check out the [documentation](https://vitepress-openapi.vercel.app/).
 
 ## License
 

--- a/components.json
+++ b/components.json
@@ -12,6 +12,6 @@
   "framework": "vite",
   "aliases": {
     "components": "src/components",
-    "utils": "vitepress-theme-openapi/lib/utils"
+    "utils": "vitepress-openapi/lib/utils"
   }
 }

--- a/dev/.vitepress/config.ts
+++ b/dev/.vitepress/config.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path'
-import { useSidebar } from 'vitepress-theme-openapi'
+import { useSidebar } from 'vitepress-openapi'
 import { defineConfigWithTheme } from 'vitepress'
 import spec from '../../docs/public/openapi.json' assert { type: 'json' }
 
@@ -9,10 +9,10 @@ const sidebar = useSidebar({
 })
 
 export default defineConfigWithTheme({
-  title: 'vitepress-theme-openapi',
-  description: 'OpenAPI theme for VitePress',
+  title: 'vitepress-openapi',
+  description: 'Generate VitePress API Documentation from OpenAPI specs.',
   themeConfig: {
-    repo: 'https://github.com/enzonotario/vitepress-theme-openapi',
+    repo: 'https://github.com/enzonotario/vitepress-openapi',
     outline: [1, 3],
     sidebar: [
       ...sidebar.generateSidebarGroups(),
@@ -71,7 +71,7 @@ export default defineConfigWithTheme({
   vite: {
     resolve: {
       alias: {
-        'vitepress-theme-openapi': resolve(__dirname, '../../src'),
+        'vitepress-openapi': resolve(__dirname, '../../src'),
       },
       dedupe: ['vue'], // avoid error when using dependencies that also use Vue
     },

--- a/dev/.vitepress/theme/index.ts
+++ b/dev/.vitepress/theme/index.ts
@@ -1,4 +1,4 @@
-import { theme, useOpenapi, useTheme } from 'vitepress-theme-openapi'
+import { theme, useOpenapi, useTheme } from 'vitepress-openapi'
 import DefaultTheme from 'vitepress/theme'
 import spec from '../../../docs/public/openapi.json' assert {type: 'json'}
 

--- a/dev/argentinadatos/index.md
+++ b/dev/argentinadatos/index.md
@@ -1,7 +1,7 @@
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">

--- a/dev/criptoya-argentina/index.md
+++ b/dev/criptoya-argentina/index.md
@@ -1,13 +1,13 @@
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">
 import { onUnmounted } from 'vue'
 import { useRoute, useData } from 'vitepress'
-import { useTheme } from 'vitepress-theme-openapi'
+import { useTheme } from 'vitepress-openapi'
 import spec from '../../docs/public/openapi-criptoya-argentina.json'
 
 const route = useRoute()

--- a/dev/custom-slots.md
+++ b/dev/custom-slots.md
@@ -1,12 +1,12 @@
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">
 import { useData } from 'vitepress'
-import { useOpenapi } from 'vitepress-theme-openapi'
+import { useOpenapi } from 'vitepress-openapi'
 
 const { isDark } = useData()
 

--- a/dev/index.md
+++ b/dev/index.md
@@ -1,3 +1,3 @@
-# vitepress-theme-openapi
+# vitepress-openapi
 
-OpenAPI theme for VitePress.
+VitePress OpenAPI.

--- a/dev/multiple-specs/buyMuseumTickets.md
+++ b/dev/multiple-specs/buyMuseumTickets.md
@@ -1,12 +1,12 @@
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">
 import { useRoute, useData } from 'vitepress'
-import { useOpenapi } from 'vitepress-theme-openapi'
+import { useOpenapi } from 'vitepress-openapi'
 import spec from '../../docs/public/openapi.json'
 import specV2 from '../../docs/public/openapi-v2.json'
 

--- a/dev/one-page.md
+++ b/dev/one-page.md
@@ -1,7 +1,7 @@
 ---
 aside: true
 outline: [1, 2]
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">

--- a/dev/operations/[operationId].md
+++ b/dev/operations/[operationId].md
@@ -1,12 +1,12 @@
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">
 import { useRoute, useData } from 'vitepress'
-import { useOpenapi, useTheme } from 'vitepress-theme-openapi'
+import { useOpenapi, useTheme } from 'vitepress-openapi'
 
 const route = useRoute()
 

--- a/dev/operations/[operationId].paths.js
+++ b/dev/operations/[operationId].paths.js
@@ -1,4 +1,4 @@
-import { OpenApi } from 'vitepress-theme-openapi'
+import { OpenApi } from 'vitepress-openapi'
 import spec from '../../docs/public/openapi.json' assert { type: 'json' }
 
 export default {
@@ -9,7 +9,7 @@ export default {
             return {
                 params: {
                     operationId,
-                    pageTitle: `${summary} - vitepress-theme-openapi`,
+                    pageTitle: `${summary} - vitepress-openapi`,
                 },
             }
         })

--- a/dev/plant-store/index.md
+++ b/dev/plant-store/index.md
@@ -1,7 +1,7 @@
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">

--- a/dev/response-statuses/index.md
+++ b/dev/response-statuses/index.md
@@ -1,7 +1,7 @@
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">

--- a/dev/response-types/index.md
+++ b/dev/response-types/index.md
@@ -1,7 +1,7 @@
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">

--- a/dev/scalar-galaxy/index.md
+++ b/dev/scalar-galaxy/index.md
@@ -1,7 +1,7 @@
 ---
 aside: true
 outline: [1, 2]
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">

--- a/dev/schemas/index.md
+++ b/dev/schemas/index.md
@@ -1,7 +1,7 @@
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,15 +1,15 @@
 import { resolve } from 'node:path'
 import spec from '../public/openapi.json' assert { type: 'json' }
 import { defineConfigWithTheme } from 'vitepress'
-import { useSidebar } from 'vitepress-theme-openapi'
+import { useSidebar } from 'vitepress-openapi'
 
 const sidebar = useSidebar({ spec })
 
 const gaId = 'G-ELG8ZW19X4'
 
 export default defineConfigWithTheme({
-  title: 'VitePress Theme OpenAPI',
-  description: 'A VitePress theme for OpenAPI',
+  title: 'VitePress OpenAPI',
+  description: 'Generate VitePress API Documentation from OpenAPI specs.',
   themeConfig: {
     nav: [],
 
@@ -105,7 +105,7 @@ export default defineConfigWithTheme({
     ],
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/enzonotario/vitepress-theme-openapi' },
+      { icon: 'github', link: 'https://github.com/enzonotario/vitepress-openapi' },
     ],
 
     outline: {
@@ -113,7 +113,7 @@ export default defineConfigWithTheme({
     },
 
     footer: {
-      message: 'Released under the <a href="https://github.com/enzonotario/vitepress-theme-openapi/blob/main/LICENSE">MIT License</a>.',
+      message: 'Released under the <a href="https://github.com/enzonotario/vitepress-openapi/blob/main/LICENSE">MIT License</a>.',
       copyright: 'Copyright © 2023-present <a href="https://enzonotario.me">Enzo Notario</a>',
     },
   },
@@ -134,7 +134,7 @@ export default defineConfigWithTheme({
   vite: {
     resolve: {
       alias: {
-        'vitepress-theme-openapi': resolve(__dirname, '../../'),
+        'vitepress-openapi': resolve(__dirname, '../../'),
       },
     },
   },

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,7 +1,7 @@
-import { theme, useOpenapi, useTheme } from 'vitepress-theme-openapi'
+import { theme, useOpenapi, useTheme } from 'vitepress-openapi'
 import DefaultTheme from 'vitepress/theme'
 import spec from '../../public/openapi.json' assert {type: 'json'}
-import 'vitepress-theme-openapi/dist/style.css'
+import 'vitepress-openapi/dist/style.css'
 
 export default {
   ...DefaultTheme,

--- a/docs/composables/usePlayground.md
+++ b/docs/composables/usePlayground.md
@@ -5,7 +5,7 @@ The `usePlayground` composable provides functions to manage the Playground.
 You can use the `usePlayground` composable to configure the Playground in your `.vitepress/theme/index.js` file, or in any `.md` page/file.
 
 ```ts
-import { usePlayground } from 'vitepress-theme-openapi'
+import { usePlayground } from 'vitepress-openapi'
 
 export default {
     async enhanceApp({ app, router, siteData }) {

--- a/docs/composables/useTheme.md
+++ b/docs/composables/useTheme.md
@@ -5,7 +5,7 @@ The `useTheme` composable provides functions to configure the theme.
 You can use the `useTheme` composable to configure the theme in your `.vitepress/theme/index.js` file, or in any `.md` page/file.
 
 ```ts
-import { useTheme } from 'vitepress-theme-openapi'
+import { useTheme } from 'vitepress-openapi'
 
 export default {
     async enhanceApp({app, router, siteData}) {

--- a/docs/example/one-page.md
+++ b/docs/example/one-page.md
@@ -1,7 +1,7 @@
 ---
 aside: true
 outline: [1, 2]
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">

--- a/docs/example/operations/[operationId].md
+++ b/docs/example/operations/[operationId].md
@@ -1,12 +1,12 @@
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">
 import { useRoute, useData } from 'vitepress'
-import { useOpenapi, useTheme } from 'vitepress-theme-openapi'
+import { useOpenapi, useTheme } from 'vitepress-openapi'
 
 const route = useRoute()
 

--- a/docs/example/operations/[operationId].paths.js
+++ b/docs/example/operations/[operationId].paths.js
@@ -1,4 +1,4 @@
-import { useOpenapi, httpVerbs } from 'vitepress-theme-openapi'
+import { useOpenapi, httpVerbs } from 'vitepress-openapi'
 import spec from '../../public/openapi.json' assert { type: 'json' }
 
 export default {
@@ -18,7 +18,7 @@ export default {
                         return {
                             params: {
                                 operationId,
-                                pageTitle: `${summary} - vitepress-theme-openapi`,
+                                pageTitle: `${summary} - vitepress-openapi`,
                             },
                         }
                     })

--- a/docs/example/response-statuses/index.md
+++ b/docs/example/response-statuses/index.md
@@ -1,7 +1,7 @@
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">

--- a/docs/example/response-types/index.md
+++ b/docs/example/response-types/index.md
@@ -1,7 +1,7 @@
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">

--- a/docs/example/schemas/index.md
+++ b/docs/example/schemas/index.md
@@ -1,7 +1,7 @@
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This guide will walk you through the steps to set up and use the `vitepress-theme-openapi` in your VitePress project.
+This guide will walk you through the steps to set up and use the `vitepress-openapi` in your VitePress project.
 
 ## Demo
 
@@ -22,13 +22,13 @@ To install the theme in your VitePress project, run one of the following command
 manager:
 
 ```bash
-npm install vitepress-theme-openapi
+npm install vitepress-openapi
 
-pnpm add vitepress-theme-openapi
+pnpm add vitepress-openapi
 
-yarn add vitepress-theme-openapi
+yarn add vitepress-openapi
 
-bun install vitepress-theme-openapi
+bun install vitepress-openapi
 ```
 
 ## Usage
@@ -45,8 +45,8 @@ In your `.vitepress/theme/index.js`, import the theme and configure it as follow
 import DefaultTheme from 'vitepress/theme'
 import type { Theme } from 'vitepress'
 
-import { theme, useOpenapi } from 'vitepress-theme-openapi'
-import 'vitepress-theme-openapi/dist/style.css'
+import { theme, useOpenapi } from 'vitepress-openapi'
+import 'vitepress-openapi/dist/style.css'
 
 import spec from '../../public/openapi.json' assert { type: 'json' }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,8 @@
 layout: home
 
 hero:
-  name: "VitePress Theme"
-  text: "OpenAPI"
-  tagline: "Generate documentation from OpenAPI specifications."
+  name: "VitePress OpenAPI"
+  tagline: "Integrate OpenAPI specifications into your VitePress documentation."
   actions:
     - theme: brand
       text: Get Started
@@ -14,15 +13,15 @@ hero:
       link: /example/operations/getAllData
 
 features:
+  - title: Powered by VitePress
+    details: "Leverage the power of VitePress to create fast and efficient documentation sites."
   - title: Internationalization (i18n) Support
-    details: "This theme provides built-in support for internationalization using VueI18n. Easily configure multiple languages for your documentation."
-  - title: TailwindCSS Integration
-    details: "Style your content effortlessly with the power of TailwindCSS, which is seamlessly integrated into the theme."
-  - title: Custom Components
-    details: "A collection of custom Vue components is included, making it easy to extend and customize your documentation."
+    details: "English and Spanish translations are included out of the box."
+  - title: Custom Slots
+    details: "Customize the layout of your documentation with custom slots."
 
 ---
 
 ## Notice
 
-This theme is still under development. Please report any issues or suggestions in the [GitHub repository](https://github.com/enzonotario/vitepress-theme-openapi/issues).
+This project is still under development. Please report any issues or suggestions in the [GitHub repository](https://github.com/enzonotario/vitepress-openapi/issues).

--- a/docs/layouts/all-operations.md
+++ b/docs/layouts/all-operations.md
@@ -11,7 +11,7 @@ You can use the `OASpec` component to render all operations in a single page lay
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">

--- a/docs/layouts/custom-slots.md
+++ b/docs/layouts/custom-slots.md
@@ -15,7 +15,7 @@ The `description` slot allows you to customize the operation description.
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">

--- a/docs/layouts/multiple-specs.md
+++ b/docs/layouts/multiple-specs.md
@@ -1,7 +1,7 @@
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 # Multiple specs
@@ -16,7 +16,7 @@ In this example, we are using two different specs to render the same operation.
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">

--- a/docs/layouts/one-operation.md
+++ b/docs/layouts/one-operation.md
@@ -21,7 +21,7 @@ To create operation pages, create a directory named `operations` in the `docs` d
 Example of `[operationId].paths.js`:
 
 ```ts
-import { useOpenapi, httpVerbs } from 'vitepress-theme-openapi'
+import { useOpenapi, httpVerbs } from 'vitepress-openapi'
 import spec from '../public/openapi.json' assert { type: 'json' }
 
 export default {
@@ -41,7 +41,7 @@ export default {
                         return {
                             params: {
                                 operationId,
-                                pageTitle: `${summary} - vitepress-theme-openapi`,
+                                pageTitle: `${summary} - vitepress-openapi`,
                             },
                         }
                     })
@@ -56,7 +56,7 @@ Example of `[operationId].md`:
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">
@@ -78,12 +78,12 @@ You can also configure multiple options in this `[operationId].md` file, for exa
 ---
 aside: false
 outline: false
-title: vitepress-theme-openapi
+title: vitepress-openapi
 ---
 
 <script setup lang="ts">
 import { useRoute, useData } from 'vitepress'
-import { useOpenapi, useTheme } from 'vitepress-theme-openapi'
+import { useOpenapi, useTheme } from 'vitepress-openapi'
 
 const route = useRoute()
 

--- a/docs/layouts/sidebar.md
+++ b/docs/layouts/sidebar.md
@@ -8,7 +8,7 @@ outline: false
 To automatically generate sidebar items, you can use the `useSidebar` function. Configure your `.vitepress/config.js` as follows:
 
 ```ts
-import { useSidebar, useOpenapi } from 'vitepress-theme-openapi'
+import { useSidebar, useOpenapi } from 'vitepress-openapi'
 import spec from '../public/openapi.json' assert { type: 'json' }
 
 const sidebar = useSidebar({ 

--- a/docs/tailwind.config.js
+++ b/docs/tailwind.config.js
@@ -3,7 +3,7 @@ module.exports = {
     './.vitepress/theme/**/*.{js,vue,ts,json,md}',
     './.vitepress/config.js',
     './**/*.md',
-    'node_modules/vitepress-theme-openapi/**/*.{js,jsx,ts,tsx}',
+    'node_modules/vitepress-openapi/**/*.{js,jsx,ts,tsx}',
   ],
   darkMode: 'class',
   plugins: [],

--- a/package.json
+++ b/package.json
@@ -1,29 +1,29 @@
 {
-  "name": "vitepress-theme-openapi",
+  "name": "vitepress-openapi",
   "type": "module",
-  "version": "0.0.3-alpha.34",
+  "version": "0.0.3-alpha.35",
   "packageManager": "pnpm@9.1.1",
-  "homepage": "https://vitepress-theme-openapi.vercel.app/",
+  "homepage": "https://vitepress-openapi.vercel.app/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/enzonotario/vitepress-theme-openapi.git"
+    "url": "git+https://github.com/enzonotario/vitepress-openapi.git"
   },
   "author": "Enzo Notario <hi@enzonotario.me>",
   "license": "MIT",
   "keywords": [
     "vitepress",
-    "theme",
+    "vitepress-theme",
     "openapi"
   ],
   "exports": {
     ".": {
-      "import": "./dist/vitepress-theme-openapi.es.js",
-      "require": "./dist/vitepress-theme-openapi.umd.js"
+      "import": "./dist/vitepress-openapi.es.js",
+      "require": "./dist/vitepress-openapi.umd.js"
     },
     "./dist/style.css": "./dist/style.css"
   },
-  "main": "./dist/vitepress-theme-openapi.es.js",
-  "module": "./dist/vitepress-theme-openapi.es.js",
+  "main": "./dist/vitepress-openapi.es.js",
+  "module": "./dist/vitepress-openapi.es.js",
   "types": "./dist/types/index.d.ts",
   "files": [
     "dist",

--- a/src/components/Common/OACodeBlock.vue
+++ b/src/components/Common/OACodeBlock.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, ref, watch } from 'vue'
-import { useShiki } from 'vitepress-theme-openapi/composables/useShiki'
-import { useTheme } from 'vitepress-theme-openapi'
+import { useShiki } from 'vitepress-openapi/composables/useShiki'
+import { useTheme } from 'vitepress-openapi'
 import VueJsonPretty from 'vue-json-pretty'
 import 'vue-json-pretty/lib/styles.css'
 import { destr } from 'destr'

--- a/src/components/Common/OAFooter.vue
+++ b/src/components/Common/OAFooter.vue
@@ -4,11 +4,11 @@
 <template>
   <span class="text-sm text-gray-700 dark:text-gray-300 text-center">
     {{ $t('Powered by') }} <a
-      href="https://github.com/enzonotario/vitepress-theme-openapi"
+      href="https://github.com/enzonotario/vitepress-openapi"
       target="_blank"
       class="text-blue-700 dark:text-blue-300"
     >
-      VitePress Theme OpenAPI
+      VitePress OpenAPI
     </a>
   </span>
 </template>

--- a/src/components/Common/OAHeading.vue
+++ b/src/components/Common/OAHeading.vue
@@ -1,7 +1,7 @@
 <script setup>
 import slugify from '@sindresorhus/slugify'
 import { computed, useSlots } from 'vue'
-import { useTheme } from 'vitepress-theme-openapi'
+import { useTheme } from 'vitepress-openapi'
 import { cn } from '../../lib/utils'
 
 const props = defineProps({

--- a/src/components/Common/OAInfo.vue
+++ b/src/components/Common/OAInfo.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Badge } from 'vitepress-theme-openapi/components/ui/badge'
+import { Badge } from 'vitepress-openapi/components/ui/badge'
 
 const { info, externalDocs } = defineProps({
   info: {

--- a/src/components/Common/OAJSONEditor.vue
+++ b/src/components/Common/OAJSONEditor.vue
@@ -1,7 +1,7 @@
 <script setup>
 import JsonEditorVue from 'json-editor-vue'
 import { computed } from 'vue'
-import { useTheme } from 'vitepress-theme-openapi'
+import { useTheme } from 'vitepress-openapi'
 
 const props = defineProps({
   modelValue: {

--- a/src/components/Common/OAOperation.vue
+++ b/src/components/Common/OAOperation.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, useSlots } from 'vue'
-import { Badge } from 'vitepress-theme-openapi/components/ui/badge'
+import { Badge } from 'vitepress-openapi/components/ui/badge'
 
 const props = defineProps({
   operationId: {

--- a/src/components/Common/OASpec.vue
+++ b/src/components/Common/OASpec.vue
@@ -1,7 +1,7 @@
 <script setup>
-import { OpenApi, useOpenapi } from 'vitepress-theme-openapi'
-import OAInfo from 'vitepress-theme-openapi/components/Common/OAInfo.vue'
-import OAServers from 'vitepress-theme-openapi/components/Common/OAServers.vue'
+import { OpenApi, useOpenapi } from 'vitepress-openapi'
+import OAInfo from 'vitepress-openapi/components/Common/OAInfo.vue'
+import OAServers from 'vitepress-openapi/components/Common/OAServers.vue'
 
 const props = defineProps({
   spec: {

--- a/src/components/Path/OAPath.vue
+++ b/src/components/Path/OAPath.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { defineProps } from 'vue'
-import { OpenApi, useOpenapi } from 'vitepress-theme-openapi'
-import { useTheme } from 'vitepress-theme-openapi/composables/useTheme'
+import { OpenApi, useOpenapi } from 'vitepress-openapi'
+import { useTheme } from 'vitepress-openapi/composables/useTheme'
 
 const props = defineProps({
   id: {

--- a/src/components/Path/OAPathEndpoint.vue
+++ b/src/components/Path/OAPathEndpoint.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Badge } from 'vitepress-theme-openapi/components/ui/badge'
+import { Badge } from 'vitepress-openapi/components/ui/badge'
 
 const props = defineProps({
   path: {

--- a/src/components/Playground/OAPlaygroundParameterInput.vue
+++ b/src/components/Playground/OAPlaygroundParameterInput.vue
@@ -7,8 +7,8 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from 'vitepress-theme-openapi/components/ui/select'
-import { Input } from 'vitepress-theme-openapi/components/ui/input'
+} from 'vitepress-openapi/components/ui/select'
+import { Input } from 'vitepress-openapi/components/ui/input'
 
 const props = defineProps({
   parameter: {

--- a/src/components/Playground/OAPlaygroundParameters.vue
+++ b/src/components/Playground/OAPlaygroundParameters.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { computed, defineEmits, defineProps, ref, watch } from 'vue'
-import OAJSONEditor from 'vitepress-theme-openapi/components/Common/OAJSONEditor.vue'
-import { propertiesTypesJsonRecursive } from 'vitepress-theme-openapi/lib/generateSchemaJson'
-import { usePlayground, useTheme } from 'vitepress-theme-openapi'
+import OAJSONEditor from 'vitepress-openapi/components/Common/OAJSONEditor.vue'
+import { propertiesTypesJsonRecursive } from 'vitepress-openapi/lib/generateSchemaJson'
+import { usePlayground, useTheme } from 'vitepress-openapi'
 import { useStorage } from '@vueuse/core'
-import OAPlaygroundParameterInput from 'vitepress-theme-openapi/components/Playground/OAPlaygroundParameterInput.vue'
-import OAPlaygroundSecurityInput from 'vitepress-theme-openapi/components/Playground/OAPlaygroundSecurityInput.vue'
+import OAPlaygroundParameterInput from 'vitepress-openapi/components/Playground/OAPlaygroundParameterInput.vue'
+import OAPlaygroundSecurityInput from 'vitepress-openapi/components/Playground/OAPlaygroundSecurityInput.vue'
 
 interface SecurityScheme {
   type: string

--- a/src/components/Playground/OAPlaygroundSecurityInput.vue
+++ b/src/components/Playground/OAPlaygroundSecurityInput.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, defineEmits, defineProps } from 'vue'
-import { usePlayground } from 'vitepress-theme-openapi'
-import { Input } from 'vitepress-theme-openapi/components/ui/input'
+import { usePlayground } from 'vitepress-openapi'
+import { Input } from 'vitepress-openapi/components/ui/input'
 
 const props = defineProps({
   scheme: {

--- a/src/components/Response/OAResponse.vue
+++ b/src/components/Response/OAResponse.vue
@@ -7,8 +7,8 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from 'vitepress-theme-openapi/components/ui/select'
-import { Label } from 'vitepress-theme-openapi/components/ui/label'
+} from 'vitepress-openapi/components/ui/select'
+import { Label } from 'vitepress-openapi/components/ui/label'
 
 const props = defineProps({
   operationId: {

--- a/src/components/Response/OAResponses.vue
+++ b/src/components/Response/OAResponses.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, defineProps, ref } from 'vue'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from 'vitepress-theme-openapi/components/ui/tabs'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from 'vitepress-openapi/components/ui/tabs'
 import {
   Select,
   SelectContent,
@@ -8,9 +8,9 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from 'vitepress-theme-openapi/components/ui/select'
+} from 'vitepress-openapi/components/ui/select'
 import { TabsIndicator } from 'radix-vue'
-import { useTheme } from 'vitepress-theme-openapi'
+import { useTheme } from 'vitepress-openapi'
 
 const props = defineProps({
   operationId: {

--- a/src/components/Schema/OASchemaProperty.vue
+++ b/src/components/Schema/OASchemaProperty.vue
@@ -4,7 +4,7 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-} from 'vitepress-theme-openapi/components/ui/collapsible'
+} from 'vitepress-openapi/components/ui/collapsible'
 import OASchemaBody from './OASchemaBody.vue'
 
 const props = defineProps({

--- a/src/components/Schema/OASchemaTabs.vue
+++ b/src/components/Schema/OASchemaTabs.vue
@@ -1,13 +1,13 @@
 <script setup>
 import { computed, ref } from 'vue'
 import { TabsIndicator } from 'radix-vue'
-import { useTheme } from 'vitepress-theme-openapi/composables/useTheme'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from 'vitepress-theme-openapi/components/ui/tabs'
-import { generateSchemaJson } from 'vitepress-theme-openapi/lib/generateSchemaJson'
-import { hasExample } from 'vitepress-theme-openapi/lib/hasExample'
-import { generateSchemaXml } from 'vitepress-theme-openapi/lib/generateSchemaXml'
-import { Checkbox } from 'vitepress-theme-openapi/components/ui/checkbox'
-import { Label } from 'vitepress-theme-openapi/components/ui/label'
+import { useTheme } from 'vitepress-openapi/composables/useTheme'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from 'vitepress-openapi/components/ui/tabs'
+import { generateSchemaJson } from 'vitepress-openapi/lib/generateSchemaJson'
+import { hasExample } from 'vitepress-openapi/lib/hasExample'
+import { generateSchemaXml } from 'vitepress-openapi/lib/generateSchemaXml'
+import { Checkbox } from 'vitepress-openapi/components/ui/checkbox'
+import { Label } from 'vitepress-openapi/components/ui/label'
 
 const props = defineProps({
   schema: {

--- a/src/components/Security/OASecurity.vue
+++ b/src/components/Security/OASecurity.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, defineProps, onMounted } from 'vue'
-import OASecurityContent from 'vitepress-theme-openapi/components/Security/OASecurityContent.vue'
+import OASecurityContent from 'vitepress-openapi/components/Security/OASecurityContent.vue'
 import {
   Select,
   SelectContent,
@@ -8,8 +8,8 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from 'vitepress-theme-openapi/components/ui/select'
-import { useTheme } from 'vitepress-theme-openapi'
+} from 'vitepress-openapi/components/ui/select'
+import { useTheme } from 'vitepress-openapi'
 
 const { securitySchemes, headingPrefix } = defineProps({
   securitySchemes: {

--- a/src/components/Try/OATryItButton.vue
+++ b/src/components/Try/OATryItButton.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { Button } from 'vitepress-theme-openapi/components/ui/button'
-import { Badge } from 'vitepress-theme-openapi/components/ui/badge'
+import { Button } from 'vitepress-openapi/components/ui/button'
+import { Badge } from 'vitepress-openapi/components/ui/badge'
 
 interface PlaygroundResponse {
   body: any

--- a/src/components/Try/OATryWithVariables.vue
+++ b/src/components/Try/OATryWithVariables.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { computed, defineProps, ref } from 'vue'
-import fetchToCurl from 'vitepress-theme-openapi/lib/fetchToCurl'
-import { formatJson } from 'vitepress-theme-openapi/lib/formatJson'
-import OAPlaygroundResponse from 'vitepress-theme-openapi/components/Playground/OAPlaygroundResponse.vue'
-import OAPlaygroundParameters from 'vitepress-theme-openapi/components/Playground/OAPlaygroundParameters.vue'
+import fetchToCurl from 'vitepress-openapi/lib/fetchToCurl'
+import { formatJson } from 'vitepress-openapi/lib/formatJson'
+import OAPlaygroundResponse from 'vitepress-openapi/components/Playground/OAPlaygroundResponse.vue'
+import OAPlaygroundParameters from 'vitepress-openapi/components/Playground/OAPlaygroundParameters.vue'
 
 const props = defineProps({
   operationId: {

--- a/src/components/ui/badge/Badge.vue
+++ b/src/components/ui/badge/Badge.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 import { type BadgeVariants, badgeVariants } from '.'
 
 const props = defineProps<{

--- a/src/components/ui/checkbox/Checkbox.vue
+++ b/src/components/ui/checkbox/Checkbox.vue
@@ -3,7 +3,7 @@ import { type HTMLAttributes, computed } from 'vue'
 import type { CheckboxRootEmits, CheckboxRootProps } from 'radix-vue'
 import { CheckboxIndicator, CheckboxRoot, useForwardPropsEmits } from 'radix-vue'
 import { Check } from 'lucide-vue-next'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 
 const props = defineProps<CheckboxRootProps & { class?: HTMLAttributes['class'] }>()
 const emits = defineEmits<CheckboxRootEmits>()

--- a/src/components/ui/input/Input.vue
+++ b/src/components/ui/input/Input.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { useVModel } from '@vueuse/core'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 
 const props = defineProps<{
   defaultValue?: string | number

--- a/src/components/ui/label/Label.vue
+++ b/src/components/ui/label/Label.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type HTMLAttributes, computed } from 'vue'
 import { Label, type LabelProps } from 'radix-vue'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 
 const props = defineProps<LabelProps & { class?: HTMLAttributes['class'] }>()
 

--- a/src/components/ui/select/SelectContent.vue
+++ b/src/components/ui/select/SelectContent.vue
@@ -8,7 +8,7 @@ import {
   SelectViewport,
   useForwardPropsEmits,
 } from 'radix-vue'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 import { SelectScrollDownButton, SelectScrollUpButton } from '.'
 
 defineOptions({

--- a/src/components/ui/select/SelectGroup.vue
+++ b/src/components/ui/select/SelectGroup.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type HTMLAttributes, computed } from 'vue'
 import { SelectGroup, type SelectGroupProps } from 'radix-vue'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 
 const props = defineProps<SelectGroupProps & { class?: HTMLAttributes['class'] }>()
 

--- a/src/components/ui/select/SelectItem.vue
+++ b/src/components/ui/select/SelectItem.vue
@@ -8,7 +8,7 @@ import {
   useForwardProps,
 } from 'radix-vue'
 import { Check } from 'lucide-vue-next'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 
 const props = defineProps<SelectItemProps & { class?: HTMLAttributes['class'] }>()
 

--- a/src/components/ui/select/SelectLabel.vue
+++ b/src/components/ui/select/SelectLabel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { SelectLabel, type SelectLabelProps } from 'radix-vue'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 
 const props = defineProps<SelectLabelProps & { class?: HTMLAttributes['class'] }>()
 </script>

--- a/src/components/ui/select/SelectScrollDownButton.vue
+++ b/src/components/ui/select/SelectScrollDownButton.vue
@@ -2,7 +2,7 @@
 import { type HTMLAttributes, computed } from 'vue'
 import { SelectScrollDownButton, type SelectScrollDownButtonProps, useForwardProps } from 'radix-vue'
 import { ChevronDown } from 'lucide-vue-next'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 
 const props = defineProps<SelectScrollDownButtonProps & { class?: HTMLAttributes['class'] }>()
 

--- a/src/components/ui/select/SelectScrollUpButton.vue
+++ b/src/components/ui/select/SelectScrollUpButton.vue
@@ -2,7 +2,7 @@
 import { type HTMLAttributes, computed } from 'vue'
 import { SelectScrollUpButton, type SelectScrollUpButtonProps, useForwardProps } from 'radix-vue'
 import { ChevronUp } from 'lucide-vue-next'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 
 const props = defineProps<SelectScrollUpButtonProps & { class?: HTMLAttributes['class'] }>()
 

--- a/src/components/ui/select/SelectSeparator.vue
+++ b/src/components/ui/select/SelectSeparator.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type HTMLAttributes, computed } from 'vue'
 import { SelectSeparator, type SelectSeparatorProps } from 'radix-vue'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 
 const props = defineProps<SelectSeparatorProps & { class?: HTMLAttributes['class'] }>()
 

--- a/src/components/ui/select/SelectTrigger.vue
+++ b/src/components/ui/select/SelectTrigger.vue
@@ -2,7 +2,7 @@
 import { type HTMLAttributes, computed } from 'vue'
 import { SelectIcon, SelectTrigger, type SelectTriggerProps, useForwardProps } from 'radix-vue'
 import { ChevronDown } from 'lucide-vue-next'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 
 const props = defineProps<SelectTriggerProps & { class?: HTMLAttributes['class'] }>()
 

--- a/src/components/ui/tabs/TabsContent.vue
+++ b/src/components/ui/tabs/TabsContent.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type HTMLAttributes, computed } from 'vue'
 import { TabsContent, type TabsContentProps } from 'radix-vue'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 
 const props = defineProps<TabsContentProps & { class?: HTMLAttributes['class'] }>()
 

--- a/src/components/ui/tabs/TabsList.vue
+++ b/src/components/ui/tabs/TabsList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type HTMLAttributes, computed } from 'vue'
 import { TabsList, type TabsListProps } from 'radix-vue'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 
 const props = defineProps<TabsListProps & { class?: HTMLAttributes['class'] }>()
 

--- a/src/components/ui/tabs/TabsTrigger.vue
+++ b/src/components/ui/tabs/TabsTrigger.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type HTMLAttributes, computed } from 'vue'
 import { TabsTrigger, type TabsTriggerProps, useForwardProps } from 'radix-vue'
-import { cn } from 'vitepress-theme-openapi/lib/utils'
+import { cn } from 'vitepress-openapi/lib/utils'
 import { type TabsTriggerVariants, tabsTriggerVariants } from './index'
 
 interface Props extends TabsTriggerProps {

--- a/src/composables/useShiki.ts
+++ b/src/composables/useShiki.ts
@@ -1,6 +1,6 @@
 import { ref } from 'vue'
 import { createHighlighterCoreSync, createJavaScriptRegexEngine } from 'shiki/core'
-import { useTheme } from 'vitepress-theme-openapi/composables/useTheme'
+import { useTheme } from 'vitepress-openapi/composables/useTheme'
 import type { Highlighter } from 'shiki/bundle/web'
 
 import js from 'shiki/langs/javascript.mjs'

--- a/src/composables/useSidebar.ts
+++ b/src/composables/useSidebar.ts
@@ -1,4 +1,4 @@
-import { OpenApi, httpVerbs, useOpenapi } from 'vitepress-theme-openapi'
+import { OpenApi, httpVerbs, useOpenapi } from 'vitepress-openapi'
 
 interface GenerateSidebarGroupsOptions {
   tags?: string[] | null

--- a/src/lib/OpenApi.ts
+++ b/src/lib/OpenApi.ts
@@ -1,4 +1,4 @@
-import { httpVerbs } from 'vitepress-theme-openapi'
+import { httpVerbs } from 'vitepress-openapi'
 import { dereferenceSync } from '@trojs/openapi-dereference'
 import { merge } from 'allof-merge'
 import { generateMissingOperationIds } from './generateMissingOperationIds'

--- a/src/lib/generateMissingOperationIds.ts
+++ b/src/lib/generateMissingOperationIds.ts
@@ -1,4 +1,4 @@
-import { httpVerbs } from 'vitepress-theme-openapi'
+import { httpVerbs } from 'vitepress-openapi'
 
 export function generateMissingOperationIds(value: any) {
   if (!value.paths) {

--- a/src/lib/generateMissingSummary.ts
+++ b/src/lib/generateMissingSummary.ts
@@ -1,4 +1,4 @@
-import { httpVerbs } from 'vitepress-theme-openapi'
+import { httpVerbs } from 'vitepress-openapi'
 
 export function generateMissingSummary(value: any) {
   if (!value.paths) {

--- a/test/composables/openapi.test.ts
+++ b/test/composables/openapi.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { OpenApi } from 'vitepress-theme-openapi'
+import { OpenApi } from 'vitepress-openapi'
 import { spec } from '../testsConstants'
 import { useSidebar } from './src/composables/useSidebar'
 

--- a/test/composables/useOpenapiWithNoSpec.test.ts
+++ b/test/composables/useOpenapiWithNoSpec.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { OpenApi } from 'vitepress-theme-openapi'
+import { OpenApi } from 'vitepress-openapi'
 import { useSidebar } from './src/composables/useSidebar'
 
 describe('useOpenapi with no spec', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,14 +8,14 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      'vitepress-theme-openapi': resolve(__dirname, 'src'),
+      'vitepress-openapi': resolve(__dirname, 'src'),
     },
   },
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
-      name: 'vitepress-theme-openapi',
-      fileName: format => `vitepress-theme-openapi.${format}.js`,
+      name: 'vitepress-openapi',
+      fileName: format => `vitepress-openapi.${format}.js`,
     },
     rollupOptions: {
       external: ['vue'],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

Rename package from `vitepress-theme-openapi` to `vitepress-openapi` for better clarity, as the `-theme-` prefix personally caused some confusion for me, which I later confirmed on [Reddit](https://www.reddit.com/r/node/comments/17mm2fk/comment/lp26iz7/) and [Divyansh Singh](https://twitter.com/_brc_dd) on X (thanks!).

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`
-->

## Types of changes

- Breaking change

## Migration Guide

1. Uninstall the old package:
```sh
npm uninstall vitepress-theme-openapi

pnpm uninstall vitepress-theme-openapi

yarn remove vitepress-theme-openapi

bun uninstall vitepress-theme-openapi
```

2. Install the new package:
```sh
npm install vitepress-openapi 

pnpm add vitepress-openapi

yarn add vitepress-openapi

bun install vitepress-openapi
```

3. Replace all occurrences of `vitepress-theme-openapi` with `vitepress-openapi` in your project:

```sh
# Replace all occurrences of `vitepress-theme-openapi` with `vitepress-openapi` in your project
find . -type f -exec sed -i 's/vitepress-theme-openapi/vitepress-openapi/g' {} +
```

