### PR TITLE
allow using operation id as header id

### DIFF
--- a/src/components/Common/OAHeading.vue
+++ b/src/components/Common/OAHeading.vue
@@ -13,6 +13,10 @@ const props = defineProps({
     type: String,
     default: null,
   },
+  headerId: {
+    type: String,
+    default: null,
+  },
   class: {
     type: String,
     required: false,
@@ -46,6 +50,9 @@ const slotText = computed(() => {
 })
 
 const id = computed(() => {
+  if (props.headerId) {
+    return props.headerId
+  }
   const value = props.prefix ? `${props.prefix}-${slotText.value}` : slotText.value
 
   return slugify(value, { decamelize: false })

--- a/src/components/Common/OAOperation.vue
+++ b/src/components/Common/OAOperation.vue
@@ -24,9 +24,17 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  operationIdAsHeaderId: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const slots = useSlots()
+
+const headerId = computed(() => {
+  return props.operationIdAsHeaderId ? props.operationId : null
+})
 
 const headingPrefix = computed(() => {
   if (!props.prefixHeadings) {
@@ -73,6 +81,7 @@ function hasSlot(name) {
         <OAHeading
           level="h1"
           :prefix="headingPrefix"
+          :headerId="headerId"
           :class="{
             'line-through': header.deprecated,
           }"

--- a/src/components/Common/OASpec.vue
+++ b/src/components/Common/OASpec.vue
@@ -21,6 +21,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  operationIdAsHeaderId: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const openapi = OpenApi({ spec: props.spec || useOpenapi().json })
@@ -68,6 +72,7 @@ const showServers = !props.hideServers && servers.length
           :operation-id="path[method].operationId"
           :spec="props.spec"
           :is-dark="props.isDark"
+          :operation-id-as-header-id="props.operationIdAsHeaderId"
           prefix-headings
           hide-default-footer
         />


### PR DESCRIPTION
Useful for single page with sidebar

<!-- Provide a general summary of your changes in the title above. -->

# Description
When using the OASpec component to render all operations in a single page layout, and also using useSidebar to automatically generate sidebar items, the sidebar links are not aligned with the OASpec headers.
This PR adds a prop to OASpec to support using the operation id as the header id


## Types of changes

- New feature _(non-breaking change which adds functionality)_

