### PR TITLE
fix(openapi parser): handle exceptions gracefully

### DIFF
--- a/src/components/Schema/OASchemaTabs.vue
+++ b/src/components/Schema/OASchemaTabs.vue
@@ -29,7 +29,7 @@ const themeConfig = useTheme()
 const useExample = ref(true)
 
 const schemaJson = computed(() => {
-  return generateSchemaJson(props.schema, useExample.value)
+  return generateSchemaJson(props.schema, useExample.value) ?? props.schema
 })
 
 const schemaHasExample = hasExample(props.schema)

--- a/src/lib/OpenApi.ts
+++ b/src/lib/OpenApi.ts
@@ -39,7 +39,13 @@ export function OpenApi({ spec }: { spec: any } = { spec: null }) {
 
   function getParsedSpec() {
     if (!parsedSpec) {
-      parsedSpec = dereferenceSync(merge(spec))
+      try {
+        const mergedSpec = merge(spec)
+        parsedSpec = dereferenceSync(mergedSpec)
+      } catch (error) {
+        console.warn('Failed to parse OpenAPI spec:', error)
+        parsedSpec = { ...spec }
+      }
     }
 
     return parsedSpec

--- a/src/lib/generateSchemaJson.ts
+++ b/src/lib/generateSchemaJson.ts
@@ -7,6 +7,10 @@ export function generateSchemaJson(schema: any, useExample = false) {
 
   const properties = propertiesTypesJsonRecursive(schema, useExample, new Set())
 
+  if (properties === null) {
+    return null
+  }
+
   if (typeof properties === 'string' || typeof properties === 'number' || typeof properties === 'boolean') {
     return properties
   }

--- a/test/lib/generateSchemaJson.test.ts
+++ b/test/lib/generateSchemaJson.test.ts
@@ -92,10 +92,10 @@ describe('generateSchemaJson', () => {
     expect(result).toBe(JSON.stringify({ name: 'string', age: 0, isActive: true }, null, 2))
   })
 
-  it('generates JSON for empty schema', () => {
+  it('returns null for empty schema', () => {
     const schema = {}
     const result = generateSchemaJson(schema)
-    expect(result).toBe(JSON.stringify({}, null, 2))
+    expect(result).toBe(null)
   })
 
   it('generates JSON for null schema', () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

Gracefully handles OpenAPI parser exceptions.

Currently, it doesn't handle `anyOf` properly and fails to partialy parse the specification. If any part of the spec causes an error during parsing, the entire spec remains unparsed. However, it now handles exception gracefully and falls back to displaying the original unparsed schema.

- [VitePress OpenAPI](https://stackblitz.com/edit/enzonotario-vitepress-openapi-starter-qc6frc?file=public%2Fopenapi.json)
- [Sandbox Scalar](https://sandbox.scalar.com/e/3NDUS)

## Related issues/external references

Partially fixes #78 

## Types of changes

- Bug fix
