### PR TITLE
examples && re-use parsedSpec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vitepress-openapi",
   "type": "module",
-  "version": "0.0.3-alpha.40",
+  "version": "0.0.3-alpha.41",
   "packageManager": "pnpm@9.1.1",
   "homepage": "https://vitepress-openapi.vercel.app/",
   "repository": {

--- a/src/components/Common/OASpec.vue
+++ b/src/components/Common/OASpec.vue
@@ -37,6 +37,8 @@ const spec = props.spec || useOpenapi().json
 
 const openapi = OpenApi({ spec })
 
+const parsedSpec = openapi.getParsedSpec()
+
 const servers = openapi.getServers()
 
 const info = openapi.getInfo()
@@ -58,12 +60,14 @@ const groupByTags = props.groupByTags ?? themeConfig.getSpecConfig().groupByTags
 
     <hr v-if="showInfo || showServers">
 
-    <template v-if="groupByTags && openapi.getOperationsTags().length">
-      <OAPathsByTags :spec="spec" :paths="openapi.getPaths()" />
-    </template>
-    <template v-else>
-      <OAPaths :spec="spec" :paths="openapi.getPaths()" />
-    </template>
+    <OAPathsByTags
+      v-if="groupByTags && openapi.getOperationsTags().length" :spec="spec"
+      :parsed-spec="parsedSpec" :paths="openapi.getPaths()"
+    />
+    <OAPaths
+      v-else :spec="spec"
+      :parsed-spec="parsedSpec" :paths="openapi.getPaths()"
+    />
 
     <OAFooter v-if="!props.hideDefaultFooter" />
   </div>

--- a/src/components/Common/OASpec.vue
+++ b/src/components/Common/OASpec.vue
@@ -61,12 +61,16 @@ const groupByTags = props.groupByTags ?? themeConfig.getSpecConfig().groupByTags
     <hr v-if="showInfo || showServers">
 
     <OAPathsByTags
-      v-if="groupByTags && openapi.getOperationsTags().length" :spec="spec"
-      :parsed-spec="parsedSpec" :paths="openapi.getPaths()"
+      v-if="groupByTags && openapi.getOperationsTags().length"
+      :spec="spec"
+      :parsed-spec="parsedSpec"
+      :paths="openapi.getPaths()"
     />
     <OAPaths
-      v-else :spec="spec"
-      :parsed-spec="parsedSpec" :paths="openapi.getPaths()"
+      v-else
+      :spec="spec"
+      :parsed-spec="parsedSpec"
+      :paths="openapi.getPaths()"
     />
 
     <OAFooter v-if="!props.hideDefaultFooter" />

--- a/src/components/Path/OAPath.vue
+++ b/src/components/Path/OAPath.vue
@@ -12,11 +12,15 @@ const props = defineProps({
     type: Object,
     required: false,
   },
+  parsedSpec: {
+    type: Object,
+    required: false,
+  },
 })
 
 const theme = useTheme()
 
-const openapi = OpenApi({ spec: props.spec || useOpenapi().json })
+const openapi = OpenApi({ spec: props.spec || useOpenapi().json, parsedSpec: props.parsedSpec })
 
 const operation = openapi.getOperation(props.id)
 

--- a/src/components/Path/OAPaths.vue
+++ b/src/components/Path/OAPaths.vue
@@ -6,6 +6,10 @@ const { spec, paths, isDark } = defineProps({
     type: Object,
     required: true,
   },
+  parsedSpec: {
+    type: Object,
+    required: false,
+  },
   paths: {
     type: Object,
     required: true,
@@ -30,6 +34,7 @@ const { spec, paths, isDark } = defineProps({
       <OAOperation
         :operation-id="path[method].operationId"
         :spec="spec"
+        :parsed-spec="parsedSpec"
         :is-dark="isDark"
         prefix-headings
         hide-default-footer

--- a/src/components/Path/OAPathsByTags.vue
+++ b/src/components/Path/OAPathsByTags.vue
@@ -11,6 +11,10 @@ const props = defineProps({
     type: Object,
     required: true,
   },
+  parsedSpec: {
+    type: Object,
+    required: false,
+  },
   paths: {
     type: Object,
     required: true,
@@ -27,7 +31,7 @@ const themeConfig = useTheme()
 
 const spec = props.spec || useOpenapi().json
 
-const openapi = OpenApi({ spec })
+const openapi = OpenApi({ spec, parsedSpec: props.parsedSpec })
 
 const tags = openapi.getTags()
 
@@ -117,7 +121,11 @@ function onPathClick(tagPaths, hash) {
       <hr>
 
       <div class="flex flex-col space-y-10" :class="[{ hidden: !tagPaths.isOpen }]">
-        <OAPaths :spec="spec" :paths="tagPaths.paths" />
+        <OAPaths
+          :spec="spec"
+          :parsed-spec="parsedSpec"
+          :paths="tagPaths.paths"
+        />
       </div>
     </Collapsible>
   </div>

--- a/src/components/Try/OATryItButton.vue
+++ b/src/components/Try/OATryItButton.vue
@@ -71,16 +71,14 @@ async function tryIt() {
     innerResponse.body = '{}'
     setLoading(true)
 
+    const headers = props.request.headers ?? {}
+    if (props.request.body && !headers['Content-Type']) {
+      headers['Content-Type'] = 'application/json'
+    }
+
     const data = await fetch(props.request.url ?? defaultRequestUrl, {
       method: props.method.toUpperCase(),
-      headers: {
-        ...props.request.headers,
-        ...(props.request.body
-          ? {
-              'Content-Type': 'application/json',
-            }
-          : {}),
-      },
+      headers,
       body: props.request.body ? JSON.stringify(props.request.body) : null,
     })
 

--- a/src/lib/OpenApi.ts
+++ b/src/lib/OpenApi.ts
@@ -6,9 +6,16 @@ import { generateMissingSummary } from './generateMissingSummary'
 
 const DEFAULT_SERVER_URL = 'http://localhost'
 
-export function OpenApi({ spec }: { spec: any } = { spec: null }) {
-  let parsedSpec: any = null
-
+export function OpenApi({
+  spec,
+  parsedSpec,
+}: {
+  spec: any
+  parsedSpec?: any
+} = {
+  spec: null,
+  parsedSpec: null,
+}) {
   transformSpec()
 
   function transformSpec() {

--- a/src/lib/hasExample.ts
+++ b/src/lib/hasExample.ts
@@ -9,7 +9,7 @@ export function hasExample(schema: any, visited: Set<any> = new Set(), level: nu
 
   visited.add(schema)
 
-  if (schema?.example) {
+  if (schema?.example || schema?.examples) {
     return true
   }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

- fix(openapi): avoid parsing spec on every Operation, for better performance when using `OASpec`. May fix #65 
- fix(hasExample): consider `examples`
- chore(try): default Content-Type header when not present

## Related issues/external references

#65 

## Types of changes

- Bug fix