### PR TITLE
feat: avoidCirculars && lazyRendering

### DIFF
--- a/docs/composables/useTheme.md
+++ b/docs/composables/useTheme.md
@@ -136,4 +136,3 @@ export default {
 | Function        | Description                  | Default Value                                                         | Allowed Values                                                                |
 |-----------------|------------------------------|-----------------------------------------------------------------------|-------------------------------------------------------------------------------|
 | `setSpecConfig` | Sets the spec configuration. | `{ groupByTags: true, collapsePaths: false, showPathsSummary: true, avoidCirculars: false, lazyRendering: false }` | `{ groupByTags: boolean, collapsePaths: boolean, showPathsSummary: boolean, avoidCirculars: boolean, lazyRendering: boolean }` |
-```

--- a/docs/composables/useTheme.md
+++ b/docs/composables/useTheme.md
@@ -68,9 +68,11 @@ export default {
             },
             // Set spec configuration.
             spec: {
-                groupByTags: true,
-                collapsePaths: false,
-                showPathsSummary: true,
+                groupByTags: true, // Group paths by tags.
+                collapsePaths: false, // Collapse paths when grouping by tags.
+                showPathsSummary: true, // Show a summary of the paths when grouping by tags.
+                avoidCirculars: false, // Avoid circular references when parsing schemas.
+                lazyRendering: false, // Lazy render Paths and Tags components.
             },
         })
     }
@@ -133,4 +135,5 @@ export default {
 
 | Function        | Description                  | Default Value                                                         | Allowed Values                                                                |
 |-----------------|------------------------------|-----------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| `setSpecConfig` | Sets the spec configuration. | `{ groupByTags: true, collapsePaths: false, showPathsSummary: true }` | `{ groupByTags: boolean, collapsePaths: boolean, showPathsSummary: boolean }` |
+| `setSpecConfig` | Sets the spec configuration. | `{ groupByTags: true, collapsePaths: false, showPathsSummary: true, avoidCirculars: false, lazyRendering: false }` | `{ groupByTags: boolean, collapsePaths: boolean, showPathsSummary: boolean, avoidCirculars: boolean, lazyRendering: boolean }` |
+```

--- a/src/components/Common/Lazy/OALazy.vue
+++ b/src/components/Common/Lazy/OALazy.vue
@@ -41,7 +41,9 @@ const shouldRender = ref(!props.isLazy)
 if (props.isLazy) {
   onIdle(() => {
     shouldRender.value = true
-    if (props.id) { nextTick(() => lazyBus.emit({ id: props.id! })) }
+    if (props.id) {
+      nextTick(() => lazyBus.emit({ id: props.id! }))
+    }
   })
 } else if (props.id) {
   nextTick(() => lazyBus.emit({ id: props.id! }))

--- a/src/components/Common/Lazy/OALazy.vue
+++ b/src/components/Common/Lazy/OALazy.vue
@@ -1,0 +1,53 @@
+<script lang="ts" setup>
+import { nextTick, ref } from 'vue'
+
+import { lazyBus } from './lazyBus'
+
+/**
+ * Component which loads lazily when the browser is "idle"
+ * Disabled if being rendered from the server
+ *
+ * @link https://medium.com/js-dojo/lazy-rendering-in-vue-to-improve-performance-dcccd445d5f
+ * @author [Scalar](https://github.com/scalar/scalar/tree/main/packages/api-reference)
+ */
+const props = withDefaults(
+  defineProps<{
+    // Identifier for loaded event, if no ID is passed then no event is dispatched
+    id?: string
+    // To lazyload or not to lazyload, that is the question
+    isLazy?: boolean
+    // Amount of time in ms to wait before triggering requestIdleCallback
+    lazyTimeout?: number
+  }>(),
+  {
+    isLazy: true,
+    lazyTimeout: 0,
+  },
+)
+
+const onIdle = (cb = () => {}) => {
+  if (typeof window === 'undefined') {
+    // Do nothing and load on the client only
+  } else if ('requestIdleCallback' in window) {
+    setTimeout(() => window.requestIdleCallback(cb), props.lazyTimeout)
+  } else {
+    setTimeout(() => nextTick(cb), props.lazyTimeout ?? 300)
+  }
+}
+
+const shouldRender = ref(!props.isLazy)
+
+// Fire the event for non-lazy components as well to keep track of loading
+if (props.isLazy) {
+  onIdle(() => {
+    shouldRender.value = true
+    if (props.id) { nextTick(() => lazyBus.emit({ id: props.id! })) }
+  })
+} else if (props.id) {
+  nextTick(() => lazyBus.emit({ id: props.id! }))
+}
+</script>
+
+<template>
+  <slot v-if="shouldRender" />
+</template>

--- a/src/components/Common/Lazy/lazyBus.ts
+++ b/src/components/Common/Lazy/lazyBus.ts
@@ -1,0 +1,7 @@
+import { type EventBusKey, useEventBus } from '@vueuse/core'
+
+/**
+ * Setup an event bus so we can listen for loaded events.
+ */
+const lazyEventBusKey: EventBusKey<{ id: string }> = Symbol('lazyEventBus')
+export const lazyBus = useEventBus(lazyEventBusKey)

--- a/src/components/Path/OAPaths.vue
+++ b/src/components/Path/OAPaths.vue
@@ -17,7 +17,7 @@ const { openapi, paths, isDark } = defineProps({
   },
 })
 
-const operations = Object.entries(paths).reduce((acc, [pathName, path]) => {
+const operations = Object.entries(paths).reduce((acc, [_, path]) => {
   return [
     ...acc,
     ...Object.keys(path).filter(m => path[m].operationId).map((method) => {

--- a/src/components/Path/OAPaths.vue
+++ b/src/components/Path/OAPaths.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { defineProps } from 'vue'
+import OALazy from 'vitepress-openapi/components/Common/Lazy/OALazy.vue'
 
 const { openapi, paths, isDark } = defineProps({
   openapi: {
@@ -15,27 +16,33 @@ const { openapi, paths, isDark } = defineProps({
     default: false,
   },
 })
+
+const operations = Object.entries(paths).reduce((acc, [pathName, path]) => {
+  return [
+    ...acc,
+    ...Object.keys(path).filter(m => path[m].operationId).map((method) => {
+      return {
+        operationId: path[method].operationId,
+      }
+    }),
+  ]
+}, [])
 </script>
 
 <template>
-  <div
-    v-for="(path, pathName) in paths"
-    :key="pathName"
-    class="flex flex-col space-y-10"
+  <OALazy
+    v-for="(operation, operationIdx) in operations"
+    :key="operation.operationId"
+    :is-lazy="operationIdx > 0"
   >
-    <template
-      v-for="method in Object.keys(path).filter(m => path[m].operationId)"
-      :key="`${method}-${path.id}`"
-    >
-      <OAOperation
-        :operation-id="path[method].operationId"
-        :openapi="openapi"
-        :is-dark="isDark"
-        prefix-headings
-        hide-default-footer
-      />
+    <OAOperation
+      :operation-id="operation.operationId"
+      :openapi="openapi"
+      :is-dark="isDark"
+      prefix-headings
+      hide-default-footer
+    />
 
-      <hr>
-    </template>
-  </div>
+    <hr>
+  </OALazy>
 </template>

--- a/src/components/Path/OAPathsByTags.vue
+++ b/src/components/Path/OAPathsByTags.vue
@@ -144,7 +144,7 @@ const lazyRendering = themeConfig.getSpecConfig().lazyRendering.value
       <hr>
 
       <div
-        v-if="(!lazyRendering || (lazyRendering && tagPaths.isOpen))"
+        v-if="!lazyRendering || tagPaths.isOpen"
         class="flex flex-col space-y-10"
         :class="[{ hidden: !tagPaths.isOpen }]"
       >

--- a/src/components/Try/OATryWithVariables.vue
+++ b/src/components/Try/OATryWithVariables.vue
@@ -52,15 +52,13 @@ const request = ref({
 const loading = ref(false)
 
 const curl = computed(() => {
-  const headers = request.value.headers
-  if (!headers?.['Content-Type']) {
-    headers['Content-Type'] = 'application/json'
-  }
-
   return fetchToCurl({
     method: props.method.toUpperCase(),
     url: request.value.url,
-    headers,
+    headers: {
+      ...request.value.headers,
+      ...(!request.value.headers?.['Content-Type'] ? { 'Content-Type': 'application/json' } : {}),
+    },
     body: request.value.body ? formatJson(request.value.body) : null,
   })
 })

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -70,6 +70,7 @@ export interface SpecConfig {
   collapsePaths: Ref<boolean>
   showPathsSummary: Ref<boolean>
   avoidCirculars: Ref<boolean>
+  lazyRendering: Ref<boolean>
 }
 
 export interface UseThemeConfig {
@@ -139,6 +140,7 @@ const themeConfig: UseThemeConfig = {
     collapsePaths: ref(false),
     showPathsSummary: ref(true),
     avoidCirculars: ref(false),
+    lazyRendering: ref(false),
   },
 }
 
@@ -390,6 +392,10 @@ export function useTheme(config: Partial<UseThemeConfig> = {}) {
 
     if (config.avoidCirculars !== undefined) {
       themeConfig.spec.avoidCirculars.value = config.avoidCirculars
+    }
+
+    if (config.lazyRendering !== undefined) {
+      themeConfig.spec.lazyRendering.value = config.lazyRendering
     }
   }
 

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -69,6 +69,7 @@ export interface SpecConfig {
   groupByTags: Ref<boolean>
   collapsePaths: Ref<boolean>
   showPathsSummary: Ref<boolean>
+  avoidCirculars: Ref<boolean>
 }
 
 export interface UseThemeConfig {
@@ -137,6 +138,7 @@ const themeConfig: UseThemeConfig = {
     groupByTags: ref(true),
     collapsePaths: ref(false),
     showPathsSummary: ref(true),
+    avoidCirculars: ref(false),
   },
 }
 
@@ -384,6 +386,10 @@ export function useTheme(config: Partial<UseThemeConfig> = {}) {
 
     if (config.showPathsSummary !== undefined) {
       themeConfig.spec.showPathsSummary.value = config.showPathsSummary
+    }
+
+    if (config.avoidCirculars !== undefined) {
+      themeConfig.spec.avoidCirculars.value = config.avoidCirculars
     }
   }
 

--- a/src/lib/OpenApi.ts
+++ b/src/lib/OpenApi.ts
@@ -243,7 +243,7 @@ export function OpenApi({
   }
 
   return {
-    spec,
+    spec: parsedSpec ?? transformedSpec ?? spec,
     transformedSpec,
     parsedSpec,
     getBaseUrl,

--- a/src/lib/formatJson.ts
+++ b/src/lib/formatJson.ts
@@ -1,4 +1,11 @@
+import { useTheme } from '../composables/useTheme'
+import { formatJsonWithCircularRef } from './formatJsonWithCircularRef'
+
 export function formatJson(json: any): string {
+  if (useTheme().getSpecConfig().avoidCirculars.value) {
+    return formatJsonWithCircularRef(json)
+  }
+
   if (typeof json !== 'object' && typeof json !== 'undefined' && json !== null) {
     return '{}'
   }

--- a/src/lib/formatJsonWithCircularRef.ts
+++ b/src/lib/formatJsonWithCircularRef.ts
@@ -17,17 +17,17 @@ function replaceCircularDependencies(content: any) {
   const cache = new Set()
 
   return JSON.stringify(
-      content,
-      (_, value) => {
-        if (typeof value === 'object' && value !== null) {
-          if (cache.has(value)) {
-            return '[Circular]'
-          }
-
-          cache.add(value)
+    content,
+    (_, value) => {
+      if (typeof value === 'object' && value !== null) {
+        if (cache.has(value)) {
+          return '[Circular]'
         }
-        return value
-      },
-      2,
+
+        cache.add(value)
+      }
+      return value
+    },
+    2,
   )
 }

--- a/src/lib/formatJsonWithCircularRef.ts
+++ b/src/lib/formatJsonWithCircularRef.ts
@@ -1,0 +1,33 @@
+export function formatJsonWithCircularRef(json: any): string {
+  if (typeof json !== 'object' && typeof json !== 'undefined' && json !== null) {
+    return '{}'
+  }
+
+  try {
+    return JSON.stringify(json, null, 2)
+  } catch {
+    return replaceCircularDependencies(json)
+  }
+}
+
+/**
+ * JSON.stringify, but with circular dependencies replaced with '[Circular]'.
+ */
+function replaceCircularDependencies(content: any) {
+  const cache = new Set()
+
+  return JSON.stringify(
+      content,
+      (_, value) => {
+        if (typeof value === 'object' && value !== null) {
+          if (cache.has(value)) {
+            return '[Circular]'
+          }
+
+          cache.add(value)
+        }
+        return value
+      },
+      2,
+  )
+}

--- a/src/lib/generateSchemaJson.ts
+++ b/src/lib/generateSchemaJson.ts
@@ -1,9 +1,14 @@
+import { useTheme } from '../composables/useTheme'
 import { formatJson } from './formatJson'
 import { getExample } from './getExample'
 
 export function generateSchemaJson(schema: any, useExample = false) {
   if (schema === null || schema === undefined) {
     return '{}'
+  }
+
+  if (useTheme().getSpecConfig().avoidCirculars.value) {
+    schema = JSON.parse(formatJson(schema))
   }
 
   const properties = propertiesTypesJsonRecursive(schema, useExample, new Set())

--- a/src/lib/hasExample.ts
+++ b/src/lib/hasExample.ts
@@ -1,4 +1,15 @@
+import { useTheme } from '../composables/useTheme'
+import { formatJson } from './formatJson'
+
 export function hasExample(schema: any, visited: Set<any> = new Set(), level: number = 0): boolean {
+  if (!schema) {
+    return false
+  }
+
+  if (useTheme().getSpecConfig().avoidCirculars.value) {
+    schema = JSON.parse(formatJson(schema))
+  }
+
   if (visited.has(schema)) {
     if (level > 10) {
       return false // Assume no example for circular references.

--- a/test/composables/useTheme.test.ts
+++ b/test/composables/useTheme.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
 import { useTheme } from '../../src/composables/useTheme'
 
 describe('composition API', () => {
@@ -82,9 +83,10 @@ describe('composition API', () => {
     expect(theme.getSecuritySelectedScheme()).toBe('bearer')
     expect(theme.getI18nConfig().locale.value).toBe('es')
     expect(theme.getSpecConfig()).toEqual({
-      groupByTags: expect.any(Object),
-      collapsePaths: expect.any(Object),
-      showPathsSummary: expect.any(Object),
+      groupByTags: ref(false),
+      collapsePaths: ref(true),
+      showPathsSummary: ref(false),
+      avoidCirculars: ref(false),
     })
   })
 
@@ -318,9 +320,10 @@ describe('useTheme', () => {
   it('returns the spec config', () => {
     const result = themeConfig.getSpecConfig()
     expect(result).toEqual({
-      groupByTags: expect.any(Object),
-      collapsePaths: expect.any(Object),
-      showPathsSummary: expect.any(Object),
+      groupByTags: ref(true),
+      collapsePaths: ref(false),
+      showPathsSummary: ref(true),
+      avoidCirculars: ref(false),
     })
   })
 

--- a/test/composables/useTheme.test.ts
+++ b/test/composables/useTheme.test.ts
@@ -330,10 +330,18 @@ describe('useTheme', () => {
   })
 
   it('sets spec config', () => {
-    themeConfig.setSpecConfig({ groupByTags: false, collapsePaths: true, showPathsSummary: false })
+    themeConfig.setSpecConfig({
+      groupByTags: false,
+      collapsePaths: true,
+      showPathsSummary: false,
+      avoidCirculars: true,
+      lazyRendering: true,
+    })
     const result = themeConfig.getSpecConfig()
     result.groupByTags.value = false
     result.collapsePaths.value = true
     result.showPathsSummary.value = false
+    result.avoidCirculars.value = true
+    result.lazyRendering.value = true
   })
 })

--- a/test/composables/useTheme.test.ts
+++ b/test/composables/useTheme.test.ts
@@ -87,6 +87,7 @@ describe('composition API', () => {
       collapsePaths: ref(true),
       showPathsSummary: ref(false),
       avoidCirculars: ref(false),
+      lazyRendering: ref(false),
     })
   })
 
@@ -324,6 +325,7 @@ describe('useTheme', () => {
       collapsePaths: ref(false),
       showPathsSummary: ref(true),
       avoidCirculars: ref(false),
+      lazyRendering: ref(false),
     })
   })
 

--- a/test/lib/formatJsonWithCircularRef.test.ts
+++ b/test/lib/formatJsonWithCircularRef.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { formatJsonWithCircularRef } from '../../src/lib/formatJsonWithCircularRef'
+
+describe('formatJsonWithCircularRef', () => {
+  it('formats a JSON object with circular reference', () => {
+    const input: any = { key: 'value' }
+    input.circular = input
+    const output = formatJsonWithCircularRef(input)
+    expect(output).toBe(`{
+  "key": "value",
+  "circular": "[Circular]"
+}`)
+  })
+})


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

- Adds an option to avoid circular references when parsing schemas
- Adds an option to lazy render Tags and Operations (for larger schemas)

## Related issues/external references

#65 

## Types of changes

- New feature
