### PR TITLE
fix(spec): generate defaultTag for operations that has no tags

### DIFF
--- a/docs/composables/useTheme.md
+++ b/docs/composables/useTheme.md
@@ -90,6 +90,7 @@ export default {
                 showPathsSummary: true, // Show a summary of the paths when grouping by tags.
                 avoidCirculars: false, // Avoid circular references when parsing schemas.
                 lazyRendering: false, // Lazy render Paths and Tags components.
+                defaultTag: 'default', // Default tag to use when a path has no tags.
             },
         })
     }
@@ -150,6 +151,7 @@ export default {
 
 ## Spec Configuration
 
-| Function        | Description                  | Default Value                                                         | Allowed Values                                                                |
-|-----------------|------------------------------|-----------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| `setSpecConfig` | Sets the spec configuration. | `{ groupByTags: true, collapsePaths: false, showPathsSummary: true, avoidCirculars: false, lazyRendering: false }` | `{ groupByTags: boolean, collapsePaths: boolean, showPathsSummary: boolean, avoidCirculars: boolean, lazyRendering: boolean }` |
+| Function        | Description                  | Default Value                                                                                                                             | Allowed Values                                                                |
+|-----------------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| `setSpecConfig` | Sets the spec configuration. | `{ groupByTags: true, collapsePaths: false, showPathsSummary: true, avoidCirculars: false, lazyRendering: false, defaultTag: 'Default' }` | `{ groupByTags: boolean, collapsePaths: boolean, showPathsSummary: boolean, avoidCirculars: boolean, lazyRendering: boolean, defaultTag: string }` |
+```

--- a/docs/composables/useTheme.md
+++ b/docs/composables/useTheme.md
@@ -90,7 +90,7 @@ export default {
                 showPathsSummary: true, // Show a summary of the paths when grouping by tags.
                 avoidCirculars: false, // Avoid circular references when parsing schemas.
                 lazyRendering: false, // Lazy render Paths and Tags components.
-                defaultTag: 'default', // Default tag to use when a path has no tags.
+                defaultTag: 'Default', // Default tag to use when a path has no tags.
             },
         })
     }

--- a/docs/composables/useTheme.md
+++ b/docs/composables/useTheme.md
@@ -151,7 +151,6 @@ export default {
 
 ## Spec Configuration
 
-| Function        | Description                  | Default Value                                                                                                                             | Allowed Values                                                                |
-|-----------------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| Function        | Description                  | Default Value                                                                                                                             | Allowed Values                                                                                                                                     |
+|-----------------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 | `setSpecConfig` | Sets the spec configuration. | `{ groupByTags: true, collapsePaths: false, showPathsSummary: true, avoidCirculars: false, lazyRendering: false, defaultTag: 'Default' }` | `{ groupByTags: boolean, collapsePaths: boolean, showPathsSummary: boolean, avoidCirculars: boolean, lazyRendering: boolean, defaultTag: string }` |
-```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vitepress-openapi",
   "type": "module",
-  "version": "0.0.3-alpha.46",
+  "version": "0.0.3-alpha.47",
   "packageManager": "pnpm@9.1.1",
   "homepage": "https://vitepress-openapi.vercel.app/",
   "repository": {

--- a/src/components/Path/OAPathsByTags.vue
+++ b/src/components/Path/OAPathsByTags.vue
@@ -56,7 +56,7 @@ const internalTags = ref([
   ...(pathsWithoutTags.length
     ? [
         {
-          tag: t('Default'),
+          tag: t(useTheme().getSpecConfig.defaultTag),
           paths: pathsWithoutTags,
           isOpen: !themeConfig.getSpecConfig().collapsePaths.value,
         },

--- a/src/composables/useOpenapi.ts
+++ b/src/composables/useOpenapi.ts
@@ -30,6 +30,10 @@ export function useOpenapi({
   spec: null,
   config: null,
 }) {
+  if (config) {
+    useTheme(config)
+  }
+
   if (spec !== null) {
     setupOpenApi({ spec, config })
   }
@@ -49,9 +53,7 @@ export function useOpenapi({
 
   function addSchema({ id, spec, config }) {
     const openapi = createOpenApiInstance({ spec })
-    if (config) {
-      useTheme(config)
-    }
+
     schemas.set(id, {
       ...openapi,
       id,

--- a/src/composables/usePaths.ts
+++ b/src/composables/usePaths.ts
@@ -10,7 +10,7 @@ export function usePaths({
   const openapi = OpenApi({ spec, transformedSpec: transformSpec(spec) })
 
   function getTags() {
-    return openapi.getFilteredTests()
+    return openapi.getFilteredTags()
   }
 
   return {

--- a/src/composables/useSidebar.ts
+++ b/src/composables/useSidebar.ts
@@ -1,5 +1,7 @@
 import { OpenApi, httpVerbs, useOpenapi } from 'vitepress-openapi'
+import { transformSpec } from '../lib/transformSpec'
 import type { OpenAPI } from './useOpenapi'
+import { useTheme } from './useTheme'
 
 interface GenerateSidebarGroupsOptions {
   tags?: string[] | null
@@ -17,26 +19,38 @@ const defaultOptions = {
   spec: null,
   linkPrefix: '/operations/',
   tagLinkPrefix: '/tags/',
+  defaultTag: 'Default',
 }
 
 export function useSidebar({
   spec,
   linkPrefix,
   tagLinkPrefix,
+  defaultTag,
 }: {
   spec?: OpenAPI
   linkPrefix?: string
   tagLinkPrefix?: string
+  defaultTag?: string
 } = {
   ...defaultOptions,
 }) {
+  useTheme({
+    spec: {
+      defaultTag: defaultTag || defaultOptions.defaultTag,
+    },
+  })
+
   const options = {
     spec: spec || useOpenapi().json,
     linkPrefix: linkPrefix || defaultOptions.linkPrefix,
     tagLinkPrefix: tagLinkPrefix || defaultOptions.tagLinkPrefix,
   }
 
-  const openapi = OpenApi({ spec: options.spec })
+  const openapi = OpenApi({
+    spec: options.spec,
+    transformedSpec: transformSpec(options.spec),
+  })
 
   function sidebarItemTemplate(method: string, title: string) {
     return `<span class="OASidebarItem group/oaSidebarItem">
@@ -136,7 +150,7 @@ export function useSidebar({
     tags,
     linkPrefix,
   }: GenerateSidebarGroupsOptions = {}) {
-    tags = tags || openapi.getFilteredTests().map(({ name }) => name)
+    tags = tags || openapi.getFilteredTags().map(({ name }) => name)
     linkPrefix = linkPrefix || options.tagLinkPrefix
 
     if (!openapi.getPaths()) {

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -78,6 +78,7 @@ export interface SpecConfig {
   showPathsSummary: Ref<boolean>
   avoidCirculars: Ref<boolean>
   lazyRendering: Ref<boolean>
+  defaultTag: string
 }
 
 export interface UseThemeConfig {
@@ -168,6 +169,7 @@ const themeConfig: UseThemeConfig = {
     showPathsSummary: ref(true),
     avoidCirculars: ref(false),
     lazyRendering: ref(false),
+    defaultTag: 'Default',
   },
 }
 
@@ -463,6 +465,10 @@ export function useTheme(config: Partial<UseThemeConfig> = {}) {
 
     if (config.lazyRendering !== undefined) {
       themeConfig.spec.lazyRendering.value = config.lazyRendering
+    }
+
+    if (config.defaultTag !== undefined) {
+      themeConfig.spec.defaultTag = config.defaultTag
     }
   }
 

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -73,12 +73,12 @@ export interface I18nConfig {
 }
 
 export interface SpecConfig {
-  groupByTags: Ref<boolean>
-  collapsePaths: Ref<boolean>
-  showPathsSummary: Ref<boolean>
-  avoidCirculars: Ref<boolean>
-  lazyRendering: Ref<boolean>
-  defaultTag: string
+  groupByTags?: Ref<boolean>
+  collapsePaths?: Ref<boolean>
+  showPathsSummary?: Ref<boolean>
+  avoidCirculars?: Ref<boolean>
+  lazyRendering?: Ref<boolean>
+  defaultTag?: string
 }
 
 export interface UseThemeConfig {

--- a/src/lib/OpenApi.ts
+++ b/src/lib/OpenApi.ts
@@ -175,7 +175,7 @@ export function OpenApi({
               verb,
               operationId,
               summary,
-              tags,
+              tags: tags ?? [],
             }
           })
       })
@@ -235,7 +235,7 @@ export function OpenApi({
   }
 
   function getPathsWithoutTags() {
-    return filterPaths(operation => !operation?.tags)
+    return filterPaths(operation => !operation?.tags || operation.tags.length === 0)
   }
 
   function getTags() {
@@ -246,7 +246,7 @@ export function OpenApi({
       }))
   }
 
-  function getFilteredTests() {
+  function getFilteredTags() {
     const operationsTags = getOperationsTags()
 
     const tags = getTags()
@@ -284,6 +284,6 @@ export function OpenApi({
     getPathsByTags,
     getPathsWithoutTags,
     getTags,
-    getFilteredTests,
+    getFilteredTags,
   }
 }

--- a/src/lib/generateMissingTags.ts
+++ b/src/lib/generateMissingTags.ts
@@ -1,0 +1,19 @@
+import { useTheme } from 'vitepress-openapi'
+
+export function generateMissingTags(spec: any) {
+  const paths = spec.paths
+
+  if (!paths) {
+    return spec
+  }
+
+  for (const path of Object.values(paths)) {
+    for (const verb of Object.keys(path)) {
+      const operation = path[verb]
+      const tags = operation.tags || [useTheme().getSpecConfig().defaultTag]
+      operation.tags = tags
+    }
+  }
+
+  return spec
+}

--- a/src/lib/generateMissingTags.ts
+++ b/src/lib/generateMissingTags.ts
@@ -7,10 +7,12 @@ export function generateMissingTags(spec: any) {
     return spec
   }
 
+  const defaultTag = useTheme().getSpecConfig().defaultTag
+
   for (const path of Object.values(paths)) {
     for (const verb of Object.keys(path)) {
       const operation = path[verb]
-      const tags = operation.tags || [useTheme().getSpecConfig().defaultTag]
+      const tags = operation.tags || [defaultTag]
       operation.tags = tags
     }
   }

--- a/src/lib/transformSpec.ts
+++ b/src/lib/transformSpec.ts
@@ -1,5 +1,6 @@
 import { generateMissingOperationIds } from './generateMissingOperationIds'
 import { generateMissingSummary } from './generateMissingSummary'
+import { generateMissingTags } from './generateMissingTags'
 
 export function transformSpec(spec) {
   if (import.meta.env.VITE_DEBUG) {
@@ -17,6 +18,7 @@ export function transformSpec(spec) {
   if (spec?.paths) {
     spec = generateMissingOperationIds(spec)
     spec = generateMissingSummary(spec)
+    spec = generateMissingTags(spec)
   }
 
   return Object.assign({}, spec)

--- a/test/composables/openapi.test.ts
+++ b/test/composables/openapi.test.ts
@@ -139,7 +139,7 @@ describe('openapi with spec', () => {
     expect(paths).toMatchObject({})
   })
 
-  it('getPathsWithoutTags returns paths without tags', () => {
+  it('sets defaultTag for operations without tags', () => {
     const api = createOpenApiInstance({
       spec: {
         ...spec,
@@ -159,16 +159,9 @@ describe('openapi with spec', () => {
       },
     })
 
-    const paths = api.getPathsWithoutTags()
+    expect(api.getPathsWithoutTags()).toMatchObject({})
 
-    expect(paths).toMatchObject({
-      '/no-tags': {
-        get: {
-          operationId: 'getNoTags',
-          summary: 'GET /no-tags',
-        },
-      },
-    })
+    expect(api.getOperationsTags()).toEqual(['users', 'Default'])
   })
 
   it('getPathsWithoutTags returns empty array if no paths without tags', () => {

--- a/test/composables/useSidebar.test.ts
+++ b/test/composables/useSidebar.test.ts
@@ -179,10 +179,4 @@ describe('itemsByTags', () => {
       { text: 'pets', link: '/tags/pets' },
     ])
   })
-
-  it('returns an empty array when there are no paths', () => {
-    const emptySidebar = useSidebar({ spec: {} })
-    const result = emptySidebar.itemsByTags()
-    expect(result).toEqual([])
-  })
 })

--- a/test/composables/useTheme.test.ts
+++ b/test/composables/useTheme.test.ts
@@ -90,6 +90,7 @@ describe('composition API', () => {
       showPathsSummary: ref(false),
       avoidCirculars: ref(false),
       lazyRendering: ref(false),
+      defaultTag: 'Default',
     })
   })
 
@@ -328,6 +329,7 @@ describe('useTheme', () => {
       showPathsSummary: ref(true),
       avoidCirculars: ref(false),
       lazyRendering: ref(false),
+      defaultTag: 'Default',
     })
   })
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

Adds a `generateMissingTags` function to set a `defaultTag` for operations that has no tags, as a Tag is needed for sidebar/routing to group operations without tags.

## Related issues/external references

#105 (Just saw this issue when testing the reproduction)

## Types of changes

- Bug fix
