### PR TITLE
fix(PathsSummary): allows to navigate to Operations with {} chars

### DIFF
--- a/src/components/Path/OAPathsByTags.vue
+++ b/src/components/Path/OAPathsByTags.vue
@@ -74,7 +74,11 @@ const internalTags = ref([
 
 function scrollIntoViewWithOffset(hash, offset) {
   if (!import.meta.env.SSR) {
-    const element = document.querySelector(hash)
+    const element = document.querySelector(
+      hash
+        // . escape { and } characters
+        .replace(/([{}])/g, '\\$1'),
+    )
 
     if (!element) {
       return


### PR DESCRIPTION
# Description

Escapes to `{` and `}` characters to allows to navigate via hash.

## Related issues/external references

Fixes #108 

## Types of changes

- Bug fix
