### PR TITLE
feat(useSidebar): methodAliases option to customize method bag

### DIFF
--- a/docs/layouts/sidebar.md
+++ b/docs/layouts/sidebar.md
@@ -56,3 +56,37 @@ module.exports = {
     },
 }
 ```
+
+## Method Aliases
+
+By default, the following method aliases are used:
+
+```ts
+{
+    get: 'GET',
+    post: 'POST',
+    put: 'PUT',
+    delete: 'DELETE',
+    patch: 'PATCH',
+    options: 'OPTIONS',
+    head: 'HEAD',
+}
+```
+
+You can customize them by passing the `methodAliases` option to the `useSidebar` function.
+
+```ts
+const sidebar = useSidebar({ 
+    spec,
+    methodAliases: {
+        get: 'GE',
+        post: 'PO',
+        put: 'PU',
+        delete: 'DE',
+        patch: 'PA',
+        options: 'OP',
+        head: 'HE',
+    },
+})
+```
+

--- a/docs/layouts/sidebar.md
+++ b/docs/layouts/sidebar.md
@@ -59,21 +59,9 @@ module.exports = {
 
 ## Method Aliases
 
-By default, the following method aliases are used:
+By default, the methods are displayed in uppercase.
 
-```ts
-{
-    get: 'GET',
-    post: 'POST',
-    put: 'PUT',
-    delete: 'DELETE',
-    patch: 'PATCH',
-    options: 'OPTIONS',
-    head: 'HEAD',
-}
-```
-
-You can customize them by passing the `methodAliases` option to the `useSidebar` function.
+You can specify aliases for the methods by passing the `methodAliases` option to the `useSidebar` composable.
 
 ```ts
 const sidebar = useSidebar({ 

--- a/src/composables/useSidebar.ts
+++ b/src/composables/useSidebar.ts
@@ -27,11 +27,13 @@ export function useSidebar({
   linkPrefix,
   tagLinkPrefix,
   defaultTag,
+  methodAliases,
 }: {
   spec?: OpenAPI
   linkPrefix?: string
   tagLinkPrefix?: string
   defaultTag?: string
+  methodAliases?: Record<string, string>
 } = {
   ...defaultOptions,
 }) {
@@ -53,8 +55,10 @@ export function useSidebar({
   })
 
   function sidebarItemTemplate(method: string, title: string) {
+    const resolvedMethod = methodAliases?.[method] || method.toUpperCase()
+
     return `<span class="OASidebarItem group/oaSidebarItem">
-        <span class="OASidebarItem-badge OAMethodBadge--${method.toLowerCase()}">${method.toUpperCase()}</span>
+        <span class="OASidebarItem-badge OAMethodBadge--${method.toLowerCase()}">${resolvedMethod}</span>
         <span class="OASidebarItem-text text">${title}</span>
       </span>`
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

Allows to customize Method Bag via `methodAliases` option in `useSidebar` composable.

## Related issues/external references

Closes #118 

## Types of changes

- New feature
