### PR TITLE
endpoint/scroll

### DIFF
--- a/src/components/Path/OAPath.vue
+++ b/src/components/Path/OAPath.vue
@@ -135,7 +135,7 @@ provide('operationData', initOperationData(operation))
           'sm:grid-cols-1': operationCols === 1,
           'sm:grid-cols-2': operationCols === 2,
         }"
-        class="relative grid grid-cols-1 gap-4"
+        class="relative grid grid-cols-1"
       >
         <div class="OAPathContentStart flex flex-col">
           <div class="flex flex-col gap-4">

--- a/src/components/Path/OAPathEndpoint.vue
+++ b/src/components/Path/OAPathEndpoint.vue
@@ -36,22 +36,30 @@ const emits = defineEmits([
 
 <template>
   <div class="flex flex-col gap-2 text-sm bg-muted rounded p-2">
-    <div class="flex flex-row items-center gap-4 overflow-x-auto">
+    <div class="language-bash flex flex-row items-center gap-4 !overflow-hidden h-10 !my-0">
+      <button
+        :title="$t('Copy endpoint')"
+        class="copy absolute !top-0 z-50"
+      />
+
       <OAMethodBadge :method="props.method" />
-      <span class="flex flex-row flex-shrink-0 text-gray-600 dark:text-gray-400">
-        <span
-          v-if="!props.hideBaseUrl"
-          class="hidden md:inline-block"
-        >
-          {{ props.baseUrl }}
+
+      <div class="overflow-x-auto whitespace-nowrap">
+        <span class="flex flex-row flex-shrink-0 text-gray-600 dark:text-gray-400">
+          <span
+            v-if="!props.hideBaseUrl"
+            class="hidden md:inline-block"
+          >
+            {{ props.baseUrl }}
+          </span>
+          <span
+            :class="{
+              'line-through': props.deprecated,
+            }"
+            class="text-gray-800 dark:text-gray-200 font-bold select-all"
+          >{{ props.path }}</span>
         </span>
-        <span
-          :class="{
-            'line-through': props.deprecated,
-          }"
-          class="text-gray-800 dark:text-gray-200 font-bold select-all"
-        >{{ props.path }}</span>
-      </span>
+      </div>
     </div>
 
     <div

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -25,14 +25,10 @@ export function scrollIntoOperationByOperationId({
       return
     }
 
-    container = container || document.body
-
-    container.scrollTo({
+    element.scrollIntoView({
       behavior: 'smooth',
-      top:
-          element.getBoundingClientRect().top
-          - document.body.getBoundingClientRect().top
-          - offset,
+      block: 'start',
+      inline: 'nearest',
     })
 
     window.location.hash = hash

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -45,5 +45,6 @@
   "Examples": "Examples",
   "tags.goTo": "View {tag} operations",
   "or": "or",
-  "Enum": "Enum"
+  "Enum": "Enum",
+  "Copy endpoint": "Copy endpoint"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -45,5 +45,6 @@
   "Examples": "Ejemplos",
   "tags.goTo": "Ver operaciones de {tag}",
   "or": "o",
-  "Enum": "Enum"
+  "Enum": "Enum",
+  "Copy endpoint": "Copiar endpoint"
 }

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -45,5 +45,6 @@
   "Examples": "Exemplos",
   "tags.goTo": "Ver operações de {tag}",
   "or": "ou",
-  "Enum": "Enum"
+  "Enum": "Enum",
+  "Copy endpoint": "Copiar endpoint"
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

- Adds a Copy Button to Endpoint section
- Use `scrollIntoView` instead of `scrollTo` to scroll to a specific operation.

## Related issues/external references


## Types of changes

- New feature