### PR TITLE
feat(useSidebar): allows to specify sidebarGroupTemplate in itemsByPaths

### DIFF
--- a/docs/sidebar/sidebar-items.md
+++ b/docs/sidebar/sidebar-items.md
@@ -135,6 +135,11 @@ module.exports = {
                  * in `sidebarItemTemplate` function in the `useSidebar` composable.
                  */
                 //sidebarItemTemplate: (method: string, path: string): string => `[${method}] ${path}`,
+
+                /**
+                 * Optionally, you can specify a template for the sidebar groups.
+                 */
+                //sidebarGroupTemplate: (path: string, depth: number): string => path,
             }),
         ],
     },

--- a/src/composables/useSidebar.ts
+++ b/src/composables/useSidebar.ts
@@ -220,12 +220,14 @@ export function useSidebar({
     depth = 6,
     sidebarItemTemplate = sidebarItemTemplateForMethodPath,
     linkPrefix: itemLinkPrefix = linkPrefix,
+    sidebarGroupTemplate,
   }: {
     startsWith?: string
     collapsible?: boolean
     depth?: number
     sidebarItemTemplate?: (method: OpenAPIV3.HttpMethods, path: string) => string
     linkPrefix?: string
+    sidebarGroupTemplate?: (path: string, depth: number) => string
   } = {}): DefaultTheme.SidebarItem[] {
     const paths = getOpenApi().getPaths()
 
@@ -236,6 +238,7 @@ export function useSidebar({
       depth,
       itemLinkPrefix,
       sidebarItemTemplate,
+      sidebarGroupTemplate,
     })
 
     return cleanSidebarItems(sidebarItems) as DefaultTheme.SidebarItem[]

--- a/src/lib/sidebar/generateSidebarItemsByPaths.ts
+++ b/src/lib/sidebar/generateSidebarItemsByPaths.ts
@@ -13,6 +13,7 @@ export function generateSidebarItemsByPaths({
   itemLinkPrefix = '',
   depth = 6,
   sidebarItemTemplate,
+  sidebarGroupTemplate,
 }: {
   paths: OpenAPIV3.PathsObject
   startsWith?: string
@@ -20,6 +21,7 @@ export function generateSidebarItemsByPaths({
   itemLinkPrefix?: string
   depth?: number
   sidebarItemTemplate?: (method: OpenAPIV3.HttpMethods, path: string) => string
+  sidebarGroupTemplate?: (path: string, depth: number) => string
 } = {
   paths: {},
 }): OASidebarItem[] {
@@ -80,6 +82,10 @@ export function generateSidebarItemsByPaths({
 
   sidebarItems = flatSidebarItems(sidebarItems, flattenedSidebarItems, depth)
 
+  if (sidebarGroupTemplate) {
+    sidebarItems = applySidebarGroupTemplate(sidebarItems, sidebarGroupTemplate)
+  }
+
   return sidebarItems
 }
 
@@ -105,4 +111,22 @@ function findOrCreateGroup(
   }
 
   return group
+}
+
+function applySidebarGroupTemplate(
+  sidebarItems: OASidebarItem[],
+  sidebarGroupTemplate: (path: string, depth: number) => string,
+  currentDepth: number = 1,
+): OASidebarItem[] {
+  return sidebarItems.map((item) => {
+    if (item.text && item.path && item.items && item.items.length) {
+      item.text = sidebarGroupTemplate(item.path, currentDepth)
+    }
+
+    if (item.items) {
+      item.items = applySidebarGroupTemplate(item.items as OASidebarItem[], sidebarGroupTemplate, currentDepth + 1)
+    }
+
+    return item
+  })
 }

--- a/test/composables/useSidebar.itemsByPaths.test.ts
+++ b/test/composables/useSidebar.itemsByPaths.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'vitest'
 import type { DefaultTheme } from 'vitepress'
-import { useSidebar } from '../../src/composables/useSidebar'
+import { describe, expect, it } from 'vitest'
 import realSpec from '../../docs/public/openapi.json'
+import { useSidebar } from '../../src/composables/useSidebar'
 
 function cleanResult(result: (DefaultTheme.SidebarItem | DefaultTheme.SidebarItem[])): any {
   if (Array.isArray(result)) {
@@ -695,6 +695,76 @@ describe('useSidebar itemsByPaths', () => {
           },
           {
             link: '/operations/delete121',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('generate items witn sidebarGroupTemplate', () => {
+    const result = sidebar.itemsByPaths({
+      sidebarGroupTemplate: (path: string, depth: number) => `${depth} - ${path}`,
+      collapsible: false,
+    })
+
+    expect(
+      cleanResult(result),
+    ).toEqual([
+      {
+        text: '1 - /api/v1',
+        items: [
+          {
+            text: '2 - /api/v1/1',
+            items: [
+              {
+                link: '/operations/get1',
+              },
+              {
+                link: '/operations/create1',
+              },
+              {
+                text: '3 - /api/v1/1/2',
+                items: [
+                  {
+                    link: '/operations/get12',
+                  },
+                  {
+                    link: '/operations/update12',
+                  },
+                  {
+                    link: '/operations/delete12',
+                  },
+                  {
+                    text: '4 - /api/v1/1/2/{x}',
+                    items: [
+                      {
+                        link: '/operations/get12x',
+                      },
+                      {
+                        link: '/operations/update12x',
+                      },
+                      {
+                        link: '/operations/delete12x',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            text: '2 - /api/v1/987',
+            items: [
+              {
+                link: '/operations/get121',
+              },
+              {
+                link: '/operations/update987',
+              },
+              {
+                link: '/operations/delete121',
+              },
+            ],
           },
         ],
       },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

Allows to specify a custom `sidebarGroupTemplate` when using `itemsByPaths` from `useSidebar` composable.

## Related issues/external references

Closes #163 

## Types of changes

- New feature
