### PR TITLE
fix(codeSamples): header name for ApiKey auth

### DIFF
--- a/src/components/Playground/OAPlaygroundParameters.vue
+++ b/src/components/Playground/OAPlaygroundParameters.vue
@@ -93,10 +93,11 @@ function setAuthorizations(schemes: Record<string, PlaygroundSecurityScheme>) {
     return {
       type: scheme.type,
       scheme: scheme.scheme,
-      name,
+      name: scheme.name ?? name,
       playgroundValue: typeof localStorage !== 'undefined'
         ? useStorage(`--oa-authorization-${name}`, usePlayground().getSecuritySchemeDefaultValue(scheme), localStorage)
         : usePlayground().getSecuritySchemeDefaultValue(scheme),
+      label: name,
     }
   })
 }
@@ -160,7 +161,7 @@ watch(operationData.security.selectedSchemeId, () => {
           class="flex flex-col"
         >
           <div class="flex flex-row items-center space-x-2">
-            <span class="text-sm font-bold">{{ authorization.name }}</span>
+            <span class="text-sm font-bold">{{ authorization.label }}</span>
           </div>
           <div class="flex flex-row items-center space-x-2">
             <OAPlaygroundSecurityInput

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export type OperationObject = OpenAPIV3.Document | OpenAPIV3_1.OperationObject
 
 export type PlaygroundSecurityScheme = OpenAPIV3.HttpSecurityScheme & OpenAPIV3.ApiKeySecurityScheme & OpenAPIV3.OAuth2SecurityScheme & OpenAPIV3.OpenIdSecurityScheme & {
   playgroundValue: RemovableRef<any>
+  label: string
 }
 
 export interface SecurityUi extends Array<SecurityUiItem> {}

--- a/test/lib/getSecurityUi.test.ts
+++ b/test/lib/getSecurityUi.test.ts
@@ -78,7 +78,7 @@ describe('getSecurityUi', () => {
     expect(result[1].id).toBe('oauth2')
   })
 
-  it('works', () => {
+  it('correctly handles ApiKey authentication with custom header name', () => {
     const security: OpenAPIV3.SecurityRequirementObject[] = [{ ApiKeyAuth: [] }]
     const securitySchemes: Record<string, OpenAPIV3.SecuritySchemeObject> = {
       ApiKeyAuth: { type: 'apiKey', in: 'header', name: 'X-Api-Key' },

--- a/test/lib/getSecurityUi.test.ts
+++ b/test/lib/getSecurityUi.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
 import type { OpenAPIV3 } from '@scalar/openapi-types'
+import { describe, expect, it } from 'vitest'
 import { getSecurityUi } from '../../src/lib/getSecurityUi'
 
 describe('getSecurityUi', () => {
@@ -76,5 +76,21 @@ describe('getSecurityUi', () => {
     expect(result).toHaveLength(2)
     expect(result[0].id).toBe('apiKey')
     expect(result[1].id).toBe('oauth2')
+  })
+
+  it('works', () => {
+    const security: OpenAPIV3.SecurityRequirementObject[] = [{ ApiKeyAuth: [] }]
+    const securitySchemes: Record<string, OpenAPIV3.SecuritySchemeObject> = {
+      ApiKeyAuth: { type: 'apiKey', in: 'header', name: 'X-Api-Key' },
+    }
+    const result = getSecurityUi(security, securitySchemes)
+    expect(result).toEqual([
+      {
+        id: 'ApiKeyAuth',
+        schemes: {
+          ApiKeyAuth: { type: 'apiKey', in: 'header', name: 'X-Api-Key' },
+        },
+      },
+    ])
   })
 })


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

For ApiKey Authorizations, use HeaderName as Header, instead of SchemeName

## Related issues/external references

Closes #168 

## Types of changes

- Bug fix
