### PR TITLE
feat(useSidebar): allows to customize sidebarItemTemplate and sidebarGroupTemplate

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -3,6 +3,7 @@ import { defineConfigWithTheme } from 'vitepress'
 import { useSidebar } from 'vitepress-openapi'
 import { examplesPages } from '../pages'
 import spec from '../public/openapi.json' assert {type: 'json'}
+import { sidebars } from '../sidebars'
 
 const sidebar = useSidebar({
   spec,
@@ -28,180 +29,188 @@ export default defineConfigWithTheme({
       },
     ],
 
-    sidebar: [
-      {
-        text: 'Getting Started',
-        link: '/guide/getting-started',
-      },
-      {
-        text: 'Pages',
-        items: [
-          {
-            items: [
-              {
-                text: 'By Operation',
-                link: '/pages/by-operation',
-              },
-              {
-                text: 'By Spec',
-                link: '/pages/by-spec',
-              },
-              {
-                text: 'By Tag',
-                link: '/pages/by-tag',
-              },
-              {
-                text: 'Introduction',
-                link: '/pages/introduction',
-              },
-            ],
-          },
-        ],
-      },
-      {
-        text: 'Sidebar',
-        items: [
-          {
-            items: [
-              {
-                text: 'Sidebar Items',
-                link: '/sidebar/sidebar-items',
-              },
-            ],
-          },
-        ],
-      },
-      {
-        text: 'Composables',
-        items: [
-          {
-            items: [
-              {
-                text: 'useTheme',
-                link: '/composables/useTheme',
-              },
-              {
-                text: 'usePlayground',
-                link: '/composables/usePlayground',
-              },
-            ],
-          },
-        ],
-      },
-      {
-        text: 'Customizations',
-        items: [
-          {
-            items: [
-              {
-                text: 'General',
-                items: [
-                  {
-                    items: [
-                      {
-                        text: 'i18n',
-                        link: '/customizations/i18n',
-                      },
-                    ],
-                  },
-                ],
-              },
-              {
-                text: 'Operation',
-                items: [
-                  {
-                    items: [
-                      {
-                        text: 'Custom Slots',
-                        link: '/customizations/custom-slots',
-                      },
-                      {
-                        text: 'Operation Badges',
-                        link: '/customizations/operation-badges',
-                      },
-                      {
-                        text: 'Code Samples',
-                        link: '/customizations/code-samples',
-                      },
-                      {
-                        text: 'Operation tags slot',
-                        link: '/customizations/operation-tags-slot',
-                      },
-                    ],
-                  },
-                ],
-              },
-              {
-                text: 'Spec',
-                items: [
-                  {
-                    items: [
-                      {
-                        text: 'Multiple Specs',
-                        link: '/customizations/multiple-specs',
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        text: 'Example',
-        collapsed: true,
-        items: [
-          {
-            text: 'Introduction',
-            link: '/example/introduction',
-          },
-          ...sidebar.generateSidebarGroups({
-            linkPrefix: '/example/operations/',
-          }),
-          {
-            text: 'One Page',
-            link: '/example/one-page',
-          },
-        ],
-      },
-      {
-        text: 'Tests',
-        collapsed: true,
-        items: [
-          {
-            text: 'Response Types',
-            link: '/tests/response-types',
-          },
-          {
-            text: 'Response Statuses',
-            link: '/tests/response-statuses',
-          },
-          {
-            text: 'Schemas',
-            link: '/tests/schemas',
-          },
-          {
-            text: 'Parameters',
-            link: '/tests/parameters',
-          },
-          {
-            text: 'Security',
-            link: '/tests/security',
-          },
-        ],
-      },
-      {
-        text: 'Remote Examples',
-        collapsed: true,
-        items: [
-          ...examplesPages.map(page => ({
-            text: page.label,
-            link: `/examples/${page.slug}`,
-          })),
-        ],
-      },
-    ],
+    sidebar: {
+      ...sidebars,
+      '/': [
+        {
+          text: 'Getting Started',
+          link: '/guide/getting-started',
+        },
+        {
+          text: 'Pages',
+          items: [
+            {
+              items: [
+                {
+                  text: 'By Operation',
+                  link: '/pages/by-operation',
+                },
+                {
+                  text: 'By Spec',
+                  link: '/pages/by-spec',
+                },
+                {
+                  text: 'By Tag',
+                  link: '/pages/by-tag',
+                },
+                {
+                  text: 'Introduction',
+                  link: '/pages/introduction',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          text: 'Sidebar',
+          items: [
+            {
+              items: [
+                {
+                  text: 'Sidebar Items',
+                  link: '/sidebar/sidebar-items',
+                },
+                {
+                  text: 'Sidebar Examples',
+                  link: '/sidebar-examples/',
+                  target: '_blank',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          text: 'Composables',
+          items: [
+            {
+              items: [
+                {
+                  text: 'useTheme',
+                  link: '/composables/useTheme',
+                },
+                {
+                  text: 'usePlayground',
+                  link: '/composables/usePlayground',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          text: 'Customizations',
+          items: [
+            {
+              items: [
+                {
+                  text: 'General',
+                  items: [
+                    {
+                      items: [
+                        {
+                          text: 'i18n',
+                          link: '/customizations/i18n',
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  text: 'Operation',
+                  items: [
+                    {
+                      items: [
+                        {
+                          text: 'Custom Slots',
+                          link: '/customizations/custom-slots',
+                        },
+                        {
+                          text: 'Operation Badges',
+                          link: '/customizations/operation-badges',
+                        },
+                        {
+                          text: 'Code Samples',
+                          link: '/customizations/code-samples',
+                        },
+                        {
+                          text: 'Operation tags slot',
+                          link: '/customizations/operation-tags-slot',
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  text: 'Spec',
+                  items: [
+                    {
+                      items: [
+                        {
+                          text: 'Multiple Specs',
+                          link: '/customizations/multiple-specs',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          text: 'Example',
+          collapsed: true,
+          items: [
+            {
+              text: 'Introduction',
+              link: '/example/introduction',
+            },
+            ...sidebar.generateSidebarGroups({
+              linkPrefix: '/example/operations/',
+            }),
+            {
+              text: 'One Page',
+              link: '/example/one-page',
+            },
+          ],
+        },
+        {
+          text: 'Tests',
+          collapsed: true,
+          items: [
+            {
+              text: 'Response Types',
+              link: '/tests/response-types',
+            },
+            {
+              text: 'Response Statuses',
+              link: '/tests/response-statuses',
+            },
+            {
+              text: 'Schemas',
+              link: '/tests/schemas',
+            },
+            {
+              text: 'Parameters',
+              link: '/tests/parameters',
+            },
+            {
+              text: 'Security',
+              link: '/tests/security',
+            },
+          ],
+        },
+        {
+          text: 'Remote Examples',
+          collapsed: true,
+          items: [
+            ...examplesPages.map(page => ({
+              text: page.label,
+              link: `/examples/${page.slug}`,
+            })),
+          ],
+        },
+      ],
+    },
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/enzonotario/vitepress-openapi' },

--- a/docs/composables/useTheme.md
+++ b/docs/composables/useTheme.md
@@ -1,3 +1,9 @@
+---
+prev:
+  text: 'Sidebar Items'
+  link: /sidebar/sidebar-items
+---
+
 # `useTheme` composable
 
 The `useTheme` composable provides functions to configure the theme.

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,11 +10,12 @@
   },
   "devDependencies": {
     "@amoutonbrady/lz-string": "^0.1.0",
+    "@iconify/vue": "^4.3.0",
     "autoprefixer": "^10.4.19",
+    "js-beautify": "^1.15.1",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.6",
     "vitepress": "^1.6.3",
-    "vitepress-openapi": "workspace:*",
-    "@iconify/vue": "^4.3.0"
+    "vitepress-openapi": "workspace:*"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@amoutonbrady/lz-string": "^0.1.0",
     "@iconify/vue": "^4.3.0",
+    "@types/js-beautify": "^1.14.3",
     "autoprefixer": "^10.4.19",
     "js-beautify": "^1.15.1",
     "postcss": "^8.4.39",

--- a/docs/sidebar-examples/[exampleSlug].md
+++ b/docs/sidebar-examples/[exampleSlug].md
@@ -1,0 +1,30 @@
+---
+aside: false
+outline: false
+title: Sidebar Example
+---
+
+<script setup lang="ts">
+import { useRoute } from 'vitepress'
+
+const route = useRoute()
+
+const exampleSlug = route.data.params.exampleSlug
+const code = route.data.params.code
+</script>
+
+# Sidebar Example: `{{ exampleSlug }}`
+
+This is a custom sidebar example generated from the following code:
+
+```js-vue
+import { defineConfig } from 'vitepress'
+import { useSidebar } from 'vitepress-openapi'
+import spec from '../docs/public/openapi.json'
+
+{{code}}
+```
+
+--- 
+
+[Back to Sidebar Examples](/sidebar-examples/) 

--- a/docs/sidebar-examples/[exampleSlug].paths.js
+++ b/docs/sidebar-examples/[exampleSlug].paths.js
@@ -1,0 +1,14 @@
+import { examples } from '../sidebars.ts'
+
+export default {
+  paths() {
+    return examples.map(({ slug, code }) => {
+      return {
+        params: {
+          exampleSlug: slug,
+          code,
+        },
+      }
+    })
+  },
+}

--- a/docs/sidebar-examples/index.md
+++ b/docs/sidebar-examples/index.md
@@ -1,0 +1,18 @@
+---
+aside: false
+outline: false
+---
+
+<script setup>
+import { examples } from '../sidebars'
+
+const list = examples.map(example => {
+return `<ul><li><a href="/sidebar-examples/${example.slug}">${example.label}</a></li></ul>`
+}).join('\n')
+</script>
+
+# Sidebar Examples
+
+This is a collection of examples that demonstrate how to use the `useSidebar` function to generate custom sidebars.
+
+<div v-html="list"></div>

--- a/docs/sidebar/sidebar-items.md
+++ b/docs/sidebar/sidebar-items.md
@@ -1,6 +1,9 @@
 ---
 aside: false
 outline: false
+next:
+  text: 'useTheme'
+  link: /composables/useTheme
 ---
 
 <script setup>
@@ -36,7 +39,7 @@ module.exports = {
             ...sidebar.generateSidebarGroups({
                 // Optionally, you can generate sidebar items with another link prefix. Default is `/operations/`.
                 linkPrefix: '/operations/',
-                
+
                 // Optionally, you can specify a list of tags to generate sidebar items. Default is all tags.
                 //tags: [],
             }),
@@ -76,7 +79,7 @@ module.exports = {
             ...sidebar.itemsByTags({
                 // Optionally, you can generate sidebar items with another link prefix. Default is `/tags/`.
                 linkPrefix: '/tags/',
-                
+
                 // Optionally, you can specify a list of tags to generate sidebar items. Default is all tags.
                 //tags: [],
             }),
@@ -119,7 +122,7 @@ module.exports = {
                  * Optionally, you can specify if the sidebar items are collapsible. Default is true.
                  */
                 collapsible: true,
-                
+
                 /**
                  * Optionally, you can specify a depth for the sidebar items. Default is 6, which is the maximum VitePress sidebar depth.
                  */
@@ -151,3 +154,7 @@ module.exports = {
 <SandboxIframe :sandbox-data="{sandboxView: 'preview', sidebarItemsType: 'itemsByPaths'}" non-interactive iframe-class="w-[1200px]" class="h-[70vh] max-h-[700px] sticky top-[calc(var(--vp-nav-height)+16px)]" />
 
 </div>
+
+## Examples
+
+For more examples, check the [sidebar examples](/sidebar-examples/).

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -1,0 +1,122 @@
+import jsBeautify from 'js-beautify'
+import { useSidebar } from 'vitepress-openapi'
+import spec from './public/openapi.json'
+
+const sidebar = useSidebar({
+  spec,
+})
+
+export const examples = ([
+  {
+    slug: 'operationsByTags',
+    label: 'Operations Grouped By Tags',
+    config: () => {
+      return sidebar.generateSidebarGroups({
+        linkPrefix: '#',
+      })
+    },
+  },
+  {
+    slug: 'itemsByTags',
+    label: 'Items By Tags',
+    config: () => {
+      return sidebar.itemsByTags({
+        linkPrefix: '#',
+      })
+    },
+  },
+  {
+    slug: 'itemsByPaths',
+    label: 'Items By Paths',
+    config: () => {
+      return sidebar.itemsByPaths({
+        linkPrefix: '#',
+      })
+    },
+  },
+  {
+    slug: 'sidebarItemTemplate',
+    label: 'Custom Item Template',
+    config: () => {
+      return sidebar.generateSidebarGroups({
+        linkPrefix: '#',
+        sidebarItemTemplate: (method, path) => {
+          const operation = spec.paths[path]?.[method]
+
+          return `<div class="OASidebarItem group/oaSidebarItem" style="display: grid; grid-template-columns: 1fr auto;">
+        <span class="text" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${operation ? operation.summary : path}</span>
+        <span class="OASidebarItem-badge OAMethodBadge--${method.toLowerCase()}">${method.toUpperCase()}</span>
+      </div>`
+        },
+      })
+    },
+  },
+  {
+    slug: 'sidebarGroupTemplate',
+    label: 'Custom Group Template',
+    config: () => {
+      return sidebar.itemsByPaths({
+        linkPrefix: '#',
+        sidebarGroupTemplate: (path, _) => {
+          return `<span>${path}</span>`
+        },
+      })
+    },
+  },
+]).map((example) => {
+  const match = example.config.toString().match(/return (.*);/s)
+
+  if (!match) {
+    return {
+      ...example,
+      code: '',
+    }
+  }
+
+  const code = match[1]
+
+  const template = `
+export default defineConfig({
+  lang: 'en-US',
+  title: 'VitePress OpenAPI',
+  description: 'Generate VitePress API Docs from OpenAPI specifications',
+  themeConfig: {
+    sidebar: ${code.replace('openapi_default', 'spec')},
+  },
+})`
+
+  return {
+    ...example,
+    code: jsBeautify(template, {
+      indent_size: 2,
+    }),
+  }
+})
+
+export const sidebars = {
+  ...examples.reduce((acc, example) => {
+    acc[`/sidebar-examples/${example.slug}`] = [
+      {
+        items: [
+          {
+            text: '<- Sidebar Examples',
+            link: '/sidebar-examples',
+          },
+        ],
+      },
+      ...example.config(),
+    ]
+    return acc
+  }, {}),
+  '/sidebar-examples': [
+    {
+      text: 'Sidebar Examples',
+      items: [
+        ...examples.map(example => ({
+          text: example.label,
+          link: `/sidebar-examples/${example.slug}`,
+        })),
+      ],
+    },
+  ],
+}

--- a/e2e/dev/docs/.vitepress/config.ts
+++ b/e2e/dev/docs/.vitepress/config.ts
@@ -13,7 +13,7 @@ const sidebar = useSidebar({
 export default defineConfig({
   lang: 'en-US',
   title: 'VitePress OpenAPI',
-  description: 'Generate documentation from OpenAPI specifications.',
+  description: 'Generate VitePress API Docs from OpenAPI specifications',
 
   themeConfig: {
     nav: [{ text: 'API Reference', link: '/introduction' }],

--- a/e2e/dev/docs/index.md
+++ b/e2e/dev/docs/index.md
@@ -3,7 +3,7 @@ layout: home
 
 hero:
   name: "VitePress OpenAPI"
-  tagline: "Generate documentation from OpenAPI specifications."
+  tagline: "Generate VitePress API Docs from OpenAPI specifications"
   actions:
     - theme: brand
       text: API Reference

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.20(postcss@8.5.1)
+      js-beautify:
+        specifier: ^1.15.1
+        version: 1.15.1
       postcss:
         specifier: ^8.4.39
         version: 8.5.1
@@ -867,6 +870,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1306,6 +1312,10 @@ packages:
   '@vueuse/shared@12.5.0':
     resolution: {integrity: sha512-vMpcL1lStUU6O+kdj6YdHDixh0odjPAUM15uJ9f7MY781jcYkIwFA4iv2EfoIPO6vBmvutI1HxxAwmf0cx5ISQ==}
 
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1504,6 +1514,10 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -1517,6 +1531,9 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
   copy-anything@3.0.5:
     resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
@@ -1599,6 +1616,11 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  editorconfig@1.0.4:
+    resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   electron-to-chromium@1.5.88:
     resolution: {integrity: sha512-K3C2qf1o+bGzbilTDCTBhTQcMS9KW60yTAaTeeXsfvQuTDDwlokLam/AdqlqcSy9u4UainDgsHV23ksXAOgamw==}
@@ -2021,6 +2043,9 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -2072,6 +2097,15 @@ packages:
   jmespath@0.16.0:
     resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
     engines: {node: '>= 0.6.0'}
+
+  js-beautify@1.15.1:
+    resolution: {integrity: sha512-ESjNzSlt/sWE8sciZH8kBF8BPlwXPwhR6pWKAw8bw4Bwj+iZcnKW6ONWUutJ7eObuBZQpiIb8S7OYspWrKt7rA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2353,6 +2387,10 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@9.0.1:
+    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -2401,6 +2439,11 @@ packages:
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
 
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -2596,6 +2639,9 @@ packages:
 
   property-information@6.5.0:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
+
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
@@ -3835,6 +3881,8 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.18.0
 
+  '@one-ini/wasm@0.1.1': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -4316,6 +4364,8 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  abbrev@2.0.0: {}
+
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
       acorn: 8.14.0
@@ -4510,6 +4560,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@10.0.1: {}
+
   commander@4.1.1: {}
 
   comment-parser@1.4.1: {}
@@ -4517,6 +4569,11 @@ snapshots:
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
 
   copy-anything@3.0.5:
     dependencies:
@@ -4577,6 +4634,13 @@ snapshots:
       esutils: 2.0.3
 
   eastasianwidth@0.2.0: {}
+
+  editorconfig@1.0.4:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.1
+      semver: 7.6.3
 
   electron-to-chromium@1.5.88: {}
 
@@ -5128,6 +5192,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  ini@1.3.8: {}
+
   is-arrayish@0.2.1: {}
 
   is-binary-path@2.1.0:
@@ -5169,6 +5235,16 @@ snapshots:
   jiti@1.21.7: {}
 
   jmespath@0.16.0: {}
+
+  js-beautify@1.15.1:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.4
+      glob: 10.4.5
+      js-cookie: 3.0.5
+      nopt: 7.2.1
+
+  js-cookie@3.0.5: {}
 
   js-tokens@4.0.0: {}
 
@@ -5608,6 +5684,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.11
 
+  minimatch@9.0.1:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
@@ -5646,6 +5726,10 @@ snapshots:
   natural-orderby@5.0.0: {}
 
   node-releases@2.0.19: {}
+
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -5814,6 +5898,8 @@ snapshots:
   prettier@3.4.2: {}
 
   property-information@6.5.0: {}
+
+  proto-list@1.2.4: {}
 
   punycode.js@2.3.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@iconify/vue':
         specifier: ^4.3.0
         version: 4.3.0(vue@3.5.13(typescript@5.7.3))
+      '@types/js-beautify':
+        specifier: ^1.14.3
+        version: 1.14.3
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.20(postcss@8.5.1)
@@ -1062,6 +1065,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/js-beautify@1.14.3':
+    resolution: {integrity: sha512-FMbQHz+qd9DoGvgLHxeqqVPaNRffpIu5ZjozwV8hf9JAGpIOzuAf4wGbRSo8LNITHqGjmmVjaMggTT5P4v4IHg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -4049,6 +4055,8 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/js-beautify@1.14.3': {}
 
   '@types/json-schema@7.0.15': {}
 

--- a/src/lib/sidebar/generateSidebarItemsByPaths.ts
+++ b/src/lib/sidebar/generateSidebarItemsByPaths.ts
@@ -1,5 +1,5 @@
 import type { OpenAPIV3 } from '@scalar/openapi-types'
-import type { OASidebarItem } from '../../composables/useSidebar'
+import type { OASidebarItem, SidebarGroupTemplateFn, SidebarItemTemplateFn } from '../../composables/useSidebar'
 import { httpVerbs } from '../../index'
 import { ensureGroupTextSlashPrefix } from './ensureGroupTextSlashPrefix'
 import { flatSidebarItems } from './flatSidebarItems'
@@ -20,8 +20,8 @@ export function generateSidebarItemsByPaths({
   collapsible?: boolean
   itemLinkPrefix?: string
   depth?: number
-  sidebarItemTemplate?: (method: OpenAPIV3.HttpMethods, path: string) => string
-  sidebarGroupTemplate?: (path: string, depth: number) => string
+  sidebarItemTemplate?: SidebarItemTemplateFn
+  sidebarGroupTemplate?: SidebarGroupTemplateFn
 } = {
   paths: {},
 }): OASidebarItem[] {
@@ -115,7 +115,7 @@ function findOrCreateGroup(
 
 function applySidebarGroupTemplate(
   sidebarItems: OASidebarItem[],
-  sidebarGroupTemplate: (path: string, depth: number) => string,
+  sidebarGroupTemplate: SidebarGroupTemplateFn,
   currentDepth: number = 1,
 ): OASidebarItem[] {
   return sidebarItems.map((item) => {

--- a/test/composables/useSidebar.itemsByPaths.test.ts
+++ b/test/composables/useSidebar.itemsByPaths.test.ts
@@ -701,9 +701,9 @@ describe('useSidebar itemsByPaths', () => {
     ])
   })
 
-  it('generate items witn sidebarGroupTemplate', () => {
+  it('generate items with sidebarGroupTemplate', () => {
     const result = sidebar.itemsByPaths({
-      sidebarGroupTemplate: (path: string, depth: number) => `${depth} - ${path}`,
+      sidebarGroupTemplate: (path: string, depth: number = 1) => `${depth} - ${path}`,
       collapsible: false,
     })
 

--- a/test/composables/useSidebar.test.ts
+++ b/test/composables/useSidebar.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { spec } from '../testsConstants'
 import { useSidebar } from '../../src/composables/useSidebar'
+import { spec } from '../testsConstants'
 
 describe('useSidebar', () => {
   const sidebar = useSidebar({ spec })
@@ -153,3 +153,93 @@ describe('useSidebar with linkPrefix', () => {
   })
 })
 
+describe('useSidebar with sidebarItemTemplate', () => {
+  const sidebar = useSidebar({
+    spec,
+    sidebarItemTemplate: (method, title) => `<div class="test">${method} ${title}</div>`,
+  })
+
+  it('can configure sidebarItemTemplate globally', () => {
+    const result = sidebar.generateSidebarGroups()
+    expect(result).toEqual([
+      {
+        items: [
+          {
+            link: '/operations/getUsers',
+            text: '<div class="test">get GET /users</div>',
+          },
+          {
+            link: '/operations/getUser',
+            text: '<div class="test">get GET /users/{id}</div>',
+          },
+        ],
+        text: 'users',
+      },
+      {
+        items: [
+          {
+            link: '/operations/getUserPets',
+            text: '<div class="test">get Get a list of pets for a user</div>',
+          },
+        ],
+        text: 'pets',
+      },
+    ])
+  })
+
+  it('can configure sidebarItemTemplate per group', () => {
+    const result = sidebar.generateSidebarGroups()
+    expect(result).toEqual([
+      {
+        items: [
+          {
+            link: '/operations/getUsers',
+            text: '<div class="test">get GET /users</div>',
+          },
+          {
+            link: '/operations/getUser',
+            text: '<div class="test">get GET /users/{id}</div>',
+          },
+        ],
+        text: 'users',
+      },
+      {
+        items: [
+          {
+            link: '/operations/getUserPets',
+            text: '<div class="test">get Get a list of pets for a user</div>',
+          },
+        ],
+        text: 'pets',
+      },
+    ])
+
+    const result2 = sidebar.generateSidebarGroups({
+      sidebarItemTemplate: (method, title) => `<div class="test2">${method} ${title}</div>`,
+    })
+    expect(result2).toEqual([
+      {
+        items: [
+          {
+            link: '/operations/getUsers',
+            text: '<div class="test2">get GET /users</div>',
+          },
+          {
+            link: '/operations/getUser',
+            text: '<div class="test2">get GET /users/{id}</div>',
+          },
+        ],
+        text: 'users',
+      },
+      {
+        items: [
+          {
+            link: '/operations/getUserPets',
+            text: '<div class="test2">get Get a list of pets for a user</div>',
+          },
+        ],
+        text: 'pets',
+      },
+    ])
+  })
+})


### PR DESCRIPTION
# Description

Allows to customize `sidebarItemTemplate` and `sidebarGroupTemplate` at `useSidebar` level (global level), and/or `[generatorFunction]` (like `generateSidebarGroups`, `itemsByTags`, `itemsByPaths`) level (local level).

## Related issues/external references


## Types of changes

- New feature