### PR TITLE
change(CodeBlocks): disable html transform when body has > 1000 chars

### DIFF
--- a/src/components/Playground/OAPlaygroundResponse.vue
+++ b/src/components/Playground/OAPlaygroundResponse.vue
@@ -75,6 +75,8 @@ const url = computed(() => {
   return ''
 })
 
+const disableHtmlTransform = computed(() => response.body && JSON.stringify(response.body).length > 1000)
+
 function downloadBlob(blob: Blob, fileName: string) {
   const url = window.URL.createObjectURL(blob)
   const link = document.createElement('a')
@@ -92,7 +94,7 @@ function downloadBlob(blob: Blob, fileName: string) {
       :code="response.body"
       :lang="lang"
       :label="label"
-      :disable-html-transform="response.body.length > 1000"
+      :disable-html-transform="disableHtmlTransform"
       class="!my-0"
     />
     <img v-else-if="isImage" :src="response.body" alt="Response Image">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

Before it was disabling html transform when body has > 1000 rows. Now it's > 1000 chars.

## Related issues/external references


## Types of changes

- New feature
