### PR TITLE
chore(package): move tailwind packages to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-vue-next": "^0.474.0",
-    "radix-vue": "^1.9.12",
-    "tailwind-merge": "^2.6.0",
-    "tailwindcss-animate": "^1.0.7"
+    "radix-vue": "^1.9.12"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^4.1.0",
@@ -86,7 +84,9 @@
     "prettier": "^3.4.2",
     "scule": "^1.3.0",
     "shiki": "^2.1.0",
+    "tailwind-merge": "^2.6.0",
     "tailwindcss": "^3.4.17",
+    "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.7.3",
     "vite": "^6.0.11",
     "vitepress": "^1.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,12 +26,6 @@ importers:
       radix-vue:
         specifier: ^1.9.12
         version: 1.9.13(vue@3.5.13(typescript@5.7.3))
-      tailwind-merge:
-        specifier: ^2.6.0
-        version: 2.6.0
-      tailwindcss-animate:
-        specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.17)
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^4.1.0
@@ -105,9 +99,15 @@ importers:
       shiki:
         specifier: ^2.1.0
         version: 2.1.0
+      tailwind-merge:
+        specifier: ^2.6.0
+        version: 2.6.0
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.17)
       typescript:
         specifier: ^5.7.3
         version: 5.7.3


### PR DESCRIPTION
Currently installing package within non-tailwindcss project
with `pnpm` and `strict-peer-dependencies=true` is failing with:
```
(project package)
└─┬ vitepress-openapi 0.0.3-alpha.65
  └─┬ tailwindcss-animate 1.0.7
    └── ✕ missing peer tailwindcss@">=3.0.0 || insiders"
Peer dependencies that should be installed:
  tailwindcss@">=3.0.0 || insiders"
```
