### PR TITLE
fix(codeSamples)!: empty defaultHeaders

### DIFF
--- a/docs/sidebar/sidebar-items.md
+++ b/docs/sidebar/sidebar-items.md
@@ -54,6 +54,37 @@ module.exports = {
 
 </div>
 
+The `generateSidebarGroups` function returns an array of sidebar groups, with each group containing an `items` array. Each item in this array represents a sidebar entry with `link` and `text` properties. You can map over these groups to customize them according to the VitePress sidebar structure. For instance, you can add `collapsed: true` to a group object to make it collapsible by default.
+
+```ts
+import { useSidebar } from 'vitepress-openapi'
+import spec from '../public/openapi.json' with { type: 'json' }
+
+const sidebar = useSidebar({
+  spec,
+  // Optionally, you can specify a link prefix for all generated sidebar items. Default is `/operations/`.
+  linkPrefix: '/operations/',
+})
+
+module.exports = {
+  // ...
+  themeConfig: {
+    sidebar: [
+      ...sidebar.generateSidebarGroups({
+        // Optionally, you can generate sidebar items with another link prefix. Default is `/operations/`.
+        linkPrefix: '/operations/',
+
+        // Optionally, you can specify a list of tags to generate sidebar items. Default is all tags.
+        //tags: [],
+      }).map(group => ({
+        ...group,
+        collapsed: true, // Collapsible and open by default.
+      })),
+    ],
+  },
+}
+```
+
 ## Items by Tags
 
 <div class="grid grid-cols-3 gap-4">

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -11,9 +11,23 @@ export const examples = ([
     slug: 'operationsByTags',
     label: 'Operations Grouped By Tags',
     config: () => {
-      return sidebar.generateSidebarGroups({
-        linkPrefix: '/sidebar-examples/operationsByTags/',
-      })
+      return [
+        {
+          text: 'Operations',
+          items: sidebar.generateSidebarGroups({
+            linkPrefix: '/sidebar-examples/operationsByTags/',
+          }),
+        },
+        {
+          text: 'Collapsed operations',
+          items: sidebar.generateSidebarGroups({
+            linkPrefix: '/sidebar-examples/operationsByTags/',
+          }).map(group => ({
+            ...group,
+            collapsed: true,
+          })),
+        },
+      ]
     },
   },
   {

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -282,9 +282,7 @@ const themeConfig: UseThemeConfig = {
     defaultLang: 'curl',
     availableLanguages,
     generator: (lang: string, request: OARequest) => generateCodeSample(lang, request),
-    defaultHeaders: {
-      'Content-Type': 'application/json',
-    },
+    defaultHeaders: {},
   },
   linksPrefixes: {
     tags: '/tags/',


### PR DESCRIPTION
This PR replaces the current defaultHeaders by an empty object.

## Background
The current defaultHeaders add `--header 'Content-Type: application/json'` to curl code examples. While some default headers might be useful for certain APIs, having `'Content-Type: application/json'` for all requests (including GET) does not make much sense as a default.

## Types of changes
- Breaking change _(fix or feature that would cause existing functionality to change)_: Users who rely on the current Content-Type would need to add it explicitly.
