### PR TITLE
fix(OAJSONEditor): parse JSON value before emitting update

### DIFF
--- a/docs/composables/useTheme.md
+++ b/docs/composables/useTheme.md
@@ -57,6 +57,8 @@ export default {
                     mainMenuBar: false,
                     // Set the visibility of the navigation bar.
                     navigationBar: false,
+                    // Set the visibility of the status bar.
+                    statusBar: false,
                 },
             },
             operation: {
@@ -172,6 +174,7 @@ export default {
 | `setPlaygroundJsonEditorMode`          | Sets the mode of the JSON editor.          | `'tree'`      | `'text'`, `'tree'`, `'table'` |
 | `setPlaygroundJsonEditorMainMenuBar`   | Sets the visibility of the main menu bar.  | `false`       | `true`, `false`               |
 | `setPlaygroundJsonEditorNavigationBar` | Sets the visibility of the navigation bar. | `false`       | `true`, `false`               |
+| `setPlaygroundJsonEditorStatusBar`     | Sets the visibility of the status bar.     | `false`       | `true`, `false`               |
 
 ## Operation Configuration
 

--- a/src/components/Common/OAJSONEditor.vue
+++ b/src/components/Common/OAJSONEditor.vue
@@ -18,7 +18,7 @@ const emit = defineEmits(['update:modelValue'])
 
 const value = computed({
   get: () => props.modelValue,
-  set: val => emit('update:modelValue', val),
+  set: val => emit('update:modelValue', JSON.parse(val)),
 })
 
 const themeConfig = useTheme()

--- a/src/components/Common/OAJSONEditor.vue
+++ b/src/components/Common/OAJSONEditor.vue
@@ -32,6 +32,7 @@ const isDark = themeConfig.isDark
     :main-menu-bar="themeConfig.getPlaygroundJsonEditorMainMenuBar()"
     :navigation-bar="themeConfig.getPlaygroundJsonEditorNavigationBar()"
     :mode="themeConfig.getPlaygroundJsonEditorMode()"
+    :status-bar="themeConfig.getPlaygroundJsonEditorStatusBar()"
     class="oa-jse"
     :class="{
       'oa-jse-theme-dark': isDark,

--- a/src/components/Playground/OAPlaygroundResponseContent.vue
+++ b/src/components/Playground/OAPlaygroundResponseContent.vue
@@ -1,90 +1,106 @@
 <script setup lang="ts">
-import { computed, defineProps } from 'vue'
+import { computed, defineProps, onBeforeUnmount, ref, watch } from 'vue'
 import OACodeBlock from '../Common/OACodeBlock.vue'
 
-const { response } = defineProps({
-  response: {
-    type: Object,
-    required: true,
-  },
-})
+interface ResponseType {
+  type: string
+  body: any
+  headers?: Record<string, string>
+}
 
-const isJson = /json/i.test(response.type)
-const isXml = /xml/i.test(response.type)
-const isHtml = /text\/html/i.test(response.type)
-const isPlainText = /text\/plain/i.test(response.type)
-const isCsv = /text\/csv/i.test(response.type)
-const isImage = /^image\//i.test(response.type)
-const isAudio = /^audio\//i.test(response.type)
-const isDownloadable = /^application\/octet-stream/i.test(response.type)
-  || (
-    response
-    && response.headers
-    && (
-      /attachment/i.test(response.headers['Content-Disposition'])
-      || /attachment/i.test(response.headers['content-disposition'])
-      || /download/i.test(response.headers['Content-Disposition'])
-      || /download/i.test(response.headers['content-disposition'])
-    )
+const props = defineProps<{
+  response: ResponseType
+}>()
+
+const isType = (regex: RegExp) => computed(() => regex.test(props.response.type))
+
+const isHeader = (header: string, regex: RegExp) =>
+  props.response.headers
+  && Object.entries(props.response.headers).some(
+    ([k, v]) => k.toLowerCase() === header && regex.test(v),
   )
 
+const isJson = isType(/json/i)
+const isXml = isType(/xml/i)
+const isHtml = isType(/text\/html/i)
+const isPlainText = isType(/text\/plain/i)
+const isCsv = isType(/text\/csv/i)
+const isImage = isType(/^image\//i)
+const isAudio = isType(/^audio\//i)
+const isDownloadable = computed(() =>
+  /^application\/octet-stream/i.test(props.response.type)
+  || isHeader('content-disposition', /attachment|download/i),
+)
+
 const lang = computed(() => {
-  if (isJson) {
+  if (isJson.value) {
     return 'json'
   }
-  if (isXml) {
+  if (isXml.value) {
     return 'xml'
   }
-  if (isHtml) {
+  if (isHtml.value) {
     return 'html'
   }
-  if (isPlainText) {
+  if (isPlainText.value) {
     return 'plaintext'
   }
-  if (isCsv) {
+  if (isCsv.value) {
     return 'csv'
   }
   return 'plaintext'
 })
 
 const label = computed(() => {
-  if (isJson) {
+  if (isJson.value) {
     return 'JSON'
   }
-  if (isXml) {
+  if (isXml.value) {
     return 'XML'
   }
-  if (isHtml) {
+  if (isHtml.value) {
     return 'HTML'
   }
-  if (isPlainText) {
+  if (isPlainText.value) {
     return 'Plain Text'
   }
-  if (isCsv) {
+  if (isCsv.value) {
     return 'CSV'
   }
   return 'Plain Text'
 })
 
-const url = computed(() => {
-  if (isAudio) {
-    try {
-      return window.URL ? URL.createObjectURL(response.body) : ''
-    } catch { }
-  }
+const audioUrl = ref<string>('')
 
-  return ''
+watch(
+  () => props.response,
+  () => {
+    if (isAudio.value && props.response.body instanceof Blob) {
+      audioUrl.value = URL.createObjectURL(props.response.body)
+    } else {
+      audioUrl.value = ''
+    }
+  },
+  { immediate: true },
+)
+
+onBeforeUnmount(() => {
+  if (audioUrl.value) {
+    URL.revokeObjectURL(audioUrl.value)
+  }
 })
 
-const disableHtmlTransform = computed(() => response.body && JSON.stringify(response.body).length > 1000)
+const disableHtmlTransform = computed(
+  () => props.response.body && JSON.stringify(props.response.body).length > 1000,
+)
 
-function downloadBlob(blob: Blob, fileName: string) {
-  const url = window.URL.createObjectURL(blob)
+const downloadBlob = (blob: Blob, fileName: string) => {
+  const url = URL.createObjectURL(blob)
   const link = document.createElement('a')
   link.href = url
   link.download = fileName
   link.click()
-  window.URL.revokeObjectURL(url)
+  URL.revokeObjectURL(url)
 }
 </script>
 
@@ -92,26 +108,40 @@ function downloadBlob(blob: Blob, fileName: string) {
   <div>
     <OACodeBlock
       v-if="isJson || isXml || isHtml || isPlainText || isCsv"
-      :code="response.body"
+      :code="props.response.body"
       :lang="lang"
       :label="label"
       :disable-html-transform="disableHtmlTransform"
       active
       class="!m-0"
     />
-    <img v-else-if="isImage" :src="response.body" alt="Response Image">
-    <audio v-else-if="isAudio" controls class="w-full mt-2">
-      <source :src="url" :type="response.type">
+    <img
+      v-else-if="isImage"
+      :src="props.response.body"
+      :alt="$t('Response Image')"
+      style="max-width: 100%;"
+    >
+    <audio
+      v-else-if="isAudio"
+      controls
+      class="w-full mt-2"
+      :aria-label="$t('Audio response')"
+    >
+      <source :src="audioUrl" :type="props.response.type">
       {{ $t('Your browser does not support the audio element.') }}
     </audio>
     <div v-else-if="isDownloadable">
-      <button @click="downloadBlob(response.body, 'response_file')">
+      <button
+        type="button"
+        aria-label="Download file"
+        @click="downloadBlob(props.response.body, 'response_file')"
+      >
         {{ $t('Download file') }}
       </button>
     </div>
     <div v-else>
       <p>{{ $t('Unrecognized response type. Raw content:') }}</p>
-      <pre class="whitespace-pre-wrap">{{ response.body }}</pre>
+      <pre class="whitespace-pre-wrap">{{ props.response.body }}</pre>
     </div>
   </div>
 </template>

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -57,6 +57,7 @@ export interface PlaygroundConfig {
     mode: Ref<PlaygroundJsonEditorMode>
     mainMenuBar: Ref<boolean>
     navigationBar: Ref<boolean>
+    statusBar: Ref<boolean>
   }
 }
 
@@ -235,6 +236,7 @@ const themeConfig: UseThemeConfig = {
       mode: ref<PlaygroundJsonEditorMode>('tree'),
       mainMenuBar: ref<boolean>(false),
       navigationBar: ref<boolean>(false),
+      statusBar: ref<boolean>(false),
     },
   },
   security: {
@@ -367,6 +369,10 @@ export function useTheme(initialConfig: PartialUseThemeConfig = {}) {
 
     if (config?.playground?.jsonEditor?.navigationBar !== undefined) {
       setPlaygroundJsonEditorNavigationBar(config.playground.jsonEditor.navigationBar)
+    }
+
+    if (config?.playground?.jsonEditor?.statusBar !== undefined) {
+      setPlaygroundJsonEditorStatusBar(config.playground.jsonEditor.statusBar)
     }
 
     if (config?.security?.defaultScheme !== undefined) {
@@ -582,6 +588,15 @@ export function useTheme(initialConfig: PartialUseThemeConfig = {}) {
   function setPlaygroundJsonEditorNavigationBar(value: boolean) {
     // @ts-expect-error: This is a valid expression.
     themeConfig.playground.jsonEditor.navigationBar.value = value
+  }
+
+  function getPlaygroundJsonEditorStatusBar(): boolean | undefined {
+    return themeConfig?.playground?.jsonEditor?.statusBar.value
+  }
+
+  function setPlaygroundJsonEditorStatusBar(value: boolean) {
+    // @ts-expect-error: This is a valid expression.
+    themeConfig.playground.jsonEditor.statusBar.value = value
   }
 
   function getSecurityDefaultScheme(): string | null | undefined {
@@ -877,6 +892,8 @@ export function useTheme(initialConfig: PartialUseThemeConfig = {}) {
     setPlaygroundJsonEditorMainMenuBar,
     getPlaygroundJsonEditorNavigationBar,
     setPlaygroundJsonEditorNavigationBar,
+    getPlaygroundJsonEditorStatusBar,
+    setPlaygroundJsonEditorStatusBar,
     getSecurityDefaultScheme,
     setSecurityDefaultScheme,
     getOperationBadges,


### PR DESCRIPTION
# Description

The JSON editor was emitting the JSON as String, which flipped the input type from structured JSON (objects) to plain text (strings).

## Related issues/external references


## Types of changes

- Bug fix