### PR TITLE
feat(openapi): add support for prefixItems

### DIFF
--- a/docs/public/openapi-schemas.json
+++ b/docs/public/openapi-schemas.json
@@ -121,6 +121,44 @@
           }
         }
       }
+    },
+    "/tuple-array": {
+      "get": {
+        "summary": "Get a tuple array with prefixItems",
+        "operationId": "getTupleArray",
+        "description": "Example of a JSON array with prefixItems defining a tuple structure.",
+        "responses": {
+          "200": {
+            "description": "A tuple array with fixed positions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TupleArray"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mixed-array": {
+      "get": {
+        "summary": "Get a mixed array with prefixItems and items",
+        "operationId": "getMixedArray",
+        "description": "Example of a JSON array with both prefixItems and items schemas.",
+        "responses": {
+          "200": {
+            "description": "An array with fixed positions followed by additional items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MixedArray"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -380,6 +418,117 @@
             "type": "string"
           }
         }
+      },
+      "TupleArray": {
+        "type": "array",
+        "description": "A tuple array with fixed position types using prefixItems",
+        "prefixItems": [
+          {
+            "type": "string",
+            "description": "First element - always a string",
+            "example": "username"
+          },
+          {
+            "type": "number",
+            "description": "Second element - always a number",
+            "example": 42
+          },
+          {
+            "type": "boolean",
+            "description": "Third element - always a boolean",
+            "example": true
+          },
+          {
+            "type": "object",
+            "description": "Fourth element - a complex object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "example": "abc123"
+              },
+              "value": {
+                "type": "number",
+                "example": 99.5
+              }
+            }
+          },
+          {
+            "type": "array",
+            "description": "Fifth element - an array of strings",
+            "items": {
+              "type": "string"
+            },
+            "example": ["tag1", "tag2", "tag3"]
+          }
+        ],
+        "minItems": 5,
+        "maxItems": 5
+      },
+      "MixedArray": {
+        "type": "array",
+        "description": "An array with both prefixItems and items schemas",
+        "prefixItems": [
+          {
+            "type": "string",
+            "description": "First element - always a string identifier",
+            "example": "user-id-123"
+          },
+          {
+            "type": "object",
+            "description": "Second element - user metadata",
+            "properties": {
+              "name": {
+                "type": "string",
+                "example": "John Doe"
+              },
+              "role": {
+                "type": "string",
+                "enum": ["admin", "user", "guest"],
+                "example": "admin"
+              }
+            }
+          }
+        ],
+        "items": {
+          "type": "object",
+          "description": "Additional elements - data entries",
+          "properties": {
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "example": "2023-01-15T14:30:00Z"
+            },
+            "value": {
+              "type": "number",
+              "example": 42.5
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "example": ["important", "reviewed"]
+            }
+          }
+        },
+        "minItems": 2,
+        "example": [
+          "user-id-123",
+          {
+            "name": "John Doe",
+            "role": "admin"
+          },
+          {
+            "timestamp": "2023-01-15T14:30:00Z",
+            "value": 42.5,
+            "tags": ["important", "reviewed"]
+          },
+          {
+            "timestamp": "2023-01-16T09:15:00Z",
+            "value": 17.8,
+            "tags": ["pending"]
+          }
+        ]
       }
     }
   }

--- a/src/lib/examples/getSchemaUiJson.ts
+++ b/src/lib/examples/getSchemaUiJson.ts
@@ -53,6 +53,12 @@ function uiPropertyArrayToJson(property: OAProperty, useExample: boolean): any {
     return [resolveOneOfProperty(property, useExample)]
   }
 
+  if (property.meta?.hasPrefixItems && property.properties && Array.isArray(property.properties)) {
+    return property.properties.map((prop) => {
+      return uiPropertyToJson(prop, useExample)
+    })
+  }
+
   if (property.properties && Array.isArray(property.properties)) {
     return [uiPropertyObjectToJson(property.properties, useExample)]
   }

--- a/test/lib/processOpenAPI/getSchemaUi.test.ts
+++ b/test/lib/processOpenAPI/getSchemaUi.test.ts
@@ -1339,6 +1339,124 @@ const fixtures: Record<string, FixtureTest> = {
       age: 0,
     },
   },
+
+  'array with prefixItems': {
+    jsonSchema: {
+      type: 'array',
+      prefixItems: [
+        { type: 'string' },
+        { type: 'number' },
+        { type: 'boolean' },
+      ],
+    },
+    schemaUi: {
+      name: '',
+      types: ['array'],
+      required: false,
+      properties: [
+        {
+          name: '[0]',
+          types: ['string'],
+          required: false,
+          meta: {
+            isPrefixItem: true,
+            prefixItemIndex: 0,
+          },
+        },
+        {
+          name: '[1]',
+          types: ['number'],
+          required: false,
+          meta: {
+            isPrefixItem: true,
+            prefixItemIndex: 1,
+          },
+        },
+        {
+          name: '[2]',
+          types: ['boolean'],
+          required: false,
+          meta: {
+            isPrefixItem: true,
+            prefixItemIndex: 2,
+          },
+        },
+      ],
+      meta: {
+        hasPrefixItems: true,
+      },
+    },
+    schemaUiJson: [
+      'string',
+      0,
+      true,
+    ],
+  },
+
+  'array with prefixItems and items': {
+    jsonSchema: {
+      type: 'array',
+      prefixItems: [
+        { type: 'string' },
+        { type: 'number' },
+      ],
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer' },
+        },
+      },
+    },
+    schemaUi: {
+      name: '',
+      types: ['array'],
+      required: false,
+      properties: [
+        {
+          name: '[0]',
+          types: ['string'],
+          required: false,
+          meta: {
+            isPrefixItem: true,
+            prefixItemIndex: 0,
+          },
+        },
+        {
+          name: '[1]',
+          types: ['number'],
+          required: false,
+          meta: {
+            isPrefixItem: true,
+            prefixItemIndex: 1,
+          },
+        },
+        {
+          name: '[n+]',
+          types: ['object'],
+          required: false,
+          properties: [
+            { name: 'name', types: ['string'], required: false },
+            { name: 'age', types: ['integer'], required: false },
+          ],
+          meta: {
+            isAdditionalItems: true,
+          },
+        },
+      ],
+      meta: {
+        hasPrefixItems: true,
+      },
+    },
+    schemaUiJson: [
+      'string',
+      0,
+      {
+        name: 'string',
+        age: 0,
+      },
+    ],
+  },
 }
 
 describe('getSchemaUi and getSchemaUiJson from fixtures', () => {


### PR DESCRIPTION
# Description

Adds support for `prefixItems` in Schema UI.

## Related issues/external references

Closes #125, #111

## Types of changes

- New feature
