### PR TITLE
feat: add support for anyOf schemas and improve handling of anyOf/oneOf

### DIFF
--- a/docs/public/openapi-schemas.json
+++ b/docs/public/openapi-schemas.json
@@ -159,6 +159,45 @@
           }
         }
       }
+    },
+    "/complex-schema": {
+      "post": {
+        "summary": "Test complex schema with oneOf and anyOf",
+        "operationId": "testComplexSchema",
+        "description": "Example of a complex request and response schema using oneOf and anyOf.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ComplexRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Complex response with oneOf and anyOf schemas",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ComplexResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request with validation errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -529,6 +568,608 @@
             "tags": ["pending"]
           }
         ]
+      },
+      "ComplexRequest": {
+        "type": "object",
+        "required": ["id", "data"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the request",
+            "example": "req-12345"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the request was created",
+            "example": "2023-05-20T15:30:45Z"
+          },
+          "data": {
+            "description": "The main data payload that can be one of several types",
+            "oneOf": [
+              {
+                "type": "object",
+                "description": "User data",
+                "required": ["type", "user"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["user"],
+                    "example": "user"
+                  },
+                  "user": {
+                    "type": "object",
+                    "required": ["id", "name"],
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "example": "user-789"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "Jane Smith"
+                      },
+                      "email": {
+                        "type": "string",
+                        "format": "email",
+                        "example": "jane@example.com"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "description": "Product data",
+                "required": ["type", "product"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["product"],
+                    "example": "product"
+                  },
+                  "product": {
+                    "type": "object",
+                    "required": ["id", "name", "price"],
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "example": "prod-456"
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "Smartphone X"
+                      },
+                      "price": {
+                        "type": "number",
+                        "format": "float",
+                        "example": 599.99
+                      },
+                      "inStock": {
+                        "type": "boolean",
+                        "example": true
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "description": "Order data",
+                "required": ["type", "order"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["order"],
+                    "example": "order"
+                  },
+                  "order": {
+                    "type": "object",
+                    "required": ["id", "items"],
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "example": "order-123"
+                      },
+                      "customer": {
+                        "$ref": "#/components/schemas/NullableObject"
+                      },
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": ["productId", "quantity"],
+                          "properties": {
+                            "productId": {
+                              "type": "string",
+                              "example": "prod-456"
+                            },
+                            "quantity": {
+                              "type": "integer",
+                              "minimum": 1,
+                              "example": 2
+                            },
+                            "unitPrice": {
+                              "type": "number",
+                              "example": 599.99
+                            }
+                          }
+                        }
+                      },
+                      "totalAmount": {
+                        "type": "number",
+                        "example": 1199.98
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Additional metadata that can include any combination of these fields",
+            "anyOf": [
+              {
+                "type": "object",
+                "required": ["source"],
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "description": "Source of the request",
+                    "example": "web"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": ["priority"],
+                "properties": {
+                  "priority": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high"],
+                    "description": "Priority level",
+                    "example": "high"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": ["tags"],
+                "properties": {
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Tags for categorization",
+                    "example": ["important", "sales", "follow-up"]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "id": "req-12345",
+          "timestamp": "2023-05-20T15:30:45Z",
+          "data": {
+            "type": "order",
+            "order": {
+              "id": "order-123",
+              "customer": {
+                "id": "cust-456",
+                "name": "John Doe",
+                "description": "Loyal customer"
+              },
+              "items": [
+                {
+                  "productId": "prod-456",
+                  "quantity": 2,
+                  "unitPrice": 599.99
+                }
+              ],
+              "totalAmount": 1199.98
+            }
+          },
+          "metadata": {
+            "source": "web",
+            "priority": "high",
+            "tags": ["important", "sales"]
+          }
+        }
+      },
+      "ComplexResponse": {
+        "type": "object",
+        "required": ["id", "status", "result"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the response",
+            "example": "resp-67890"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["success", "partial", "error"],
+            "description": "Status of the response",
+            "example": "success"
+          },
+          "result": {
+            "description": "The result data with nested oneOf and anyOf",
+            "oneOf": [
+              {
+                "type": "object",
+                "description": "Success result",
+                "required": ["type", "data"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["success"],
+                    "example": "success"
+                  },
+                  "data": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "required": ["user"],
+                        "properties": {
+                          "user": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "example": "user-789"
+                              },
+                              "profile": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "required": ["type", "personal"],
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": ["personal"],
+                                        "example": "personal"
+                                      },
+                                      "personal": {
+                                        "type": "object",
+                                        "properties": {
+                                          "firstName": {
+                                            "type": "string",
+                                            "example": "Jane"
+                                          },
+                                          "lastName": {
+                                            "type": "string",
+                                            "example": "Smith"
+                                          },
+                                          "age": {
+                                            "type": "integer",
+                                            "example": 28
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": ["type", "business"],
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": ["business"],
+                                        "example": "business"
+                                      },
+                                      "business": {
+                                        "type": "object",
+                                        "properties": {
+                                          "companyName": {
+                                            "type": "string",
+                                            "example": "Acme Inc."
+                                          },
+                                          "position": {
+                                            "type": "string",
+                                            "example": "CEO"
+                                          },
+                                          "employeeCount": {
+                                            "type": "integer",
+                                            "example": 250
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "required": ["transaction"],
+                        "properties": {
+                          "transaction": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "example": "txn-123456"
+                              },
+                              "amount": {
+                                "type": "number",
+                                "example": 1299.99
+                              },
+                              "currency": {
+                                "type": "string",
+                                "example": "USD"
+                              },
+                              "paymentMethod": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "required": ["type", "card"],
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": ["card"],
+                                        "example": "card"
+                                      },
+                                      "card": {
+                                        "type": "object",
+                                        "properties": {
+                                          "last4": {
+                                            "type": "string",
+                                            "example": "4242"
+                                          },
+                                          "brand": {
+                                            "type": "string",
+                                            "example": "visa"
+                                          },
+                                          "expiryMonth": {
+                                            "type": "integer",
+                                            "example": 12
+                                          },
+                                          "expiryYear": {
+                                            "type": "integer",
+                                            "example": 2025
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": ["type", "bankTransfer"],
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": ["bankTransfer"],
+                                        "example": "bankTransfer"
+                                      },
+                                      "bankTransfer": {
+                                        "type": "object",
+                                        "properties": {
+                                          "accountLast4": {
+                                            "type": "string",
+                                            "example": "6789"
+                                          },
+                                          "bankName": {
+                                            "type": "string",
+                                            "example": "National Bank"
+                                          },
+                                          "transferDate": {
+                                            "type": "string",
+                                            "format": "date",
+                                            "example": "2023-05-21"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": ["type", "digitalWallet"],
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": ["digitalWallet"],
+                                        "example": "digitalWallet"
+                                      },
+                                      "digitalWallet": {
+                                        "type": "object",
+                                        "properties": {
+                                          "provider": {
+                                            "type": "string",
+                                            "example": "PayPal"
+                                          },
+                                          "email": {
+                                            "type": "string",
+                                            "format": "email",
+                                            "example": "user@example.com"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "description": "Error result",
+                "required": ["type", "error"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["error"],
+                    "example": "error"
+                  },
+                  "error": {
+                    "type": "object",
+                    "required": ["code", "message"],
+                    "properties": {
+                      "code": {
+                        "type": "string",
+                        "example": "INVALID_REQUEST"
+                      },
+                      "message": {
+                        "type": "string",
+                        "example": "The request contains invalid data"
+                      },
+                      "details": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "example": "data.user.email"
+                            },
+                            "issue": {
+                              "type": "string",
+                              "example": "Invalid email format"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Additional metadata with anyOf",
+            "anyOf": [
+              {
+                "type": "object",
+                "required": ["processingTime"],
+                "properties": {
+                  "processingTime": {
+                    "type": "number",
+                    "description": "Time taken to process the request in ms",
+                    "example": 235.45
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": ["region"],
+                "properties": {
+                  "region": {
+                    "type": "string",
+                    "description": "Server region that processed the request",
+                    "example": "us-west-1"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": ["version"],
+                "properties": {
+                  "version": {
+                    "type": "string",
+                    "description": "API version",
+                    "example": "v2.3.1"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "id": "resp-67890",
+          "status": "success",
+          "result": {
+            "type": "success",
+            "data": {
+              "transaction": {
+                "id": "txn-123456",
+                "amount": 1299.99,
+                "currency": "USD",
+                "paymentMethod": {
+                  "type": "card",
+                  "card": {
+                    "last4": "4242",
+                    "brand": "visa",
+                    "expiryMonth": 12,
+                    "expiryYear": 2025
+                  }
+                }
+              }
+            }
+          },
+          "metadata": {
+            "processingTime": 235.45,
+            "region": "us-west-1",
+            "version": "v2.3.1"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "message"],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Error code",
+                "example": "VALIDATION_ERROR"
+              },
+              "message": {
+                "type": "string",
+                "description": "Human-readable error message",
+                "example": "The request contains validation errors"
+              },
+              "details": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["field", "message"],
+                  "properties": {
+                    "field": {
+                      "type": "string",
+                      "description": "Field with the error",
+                      "example": "data.user.email"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Error message for this field",
+                      "example": "Must be a valid email address"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "example": {
+          "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "The request contains validation errors",
+            "details": [
+              {
+                "field": "data.user.email",
+                "message": "Must be a valid email address"
+              },
+              {
+                "field": "metadata.priority",
+                "message": "Must be one of: low, medium, high"
+              }
+            ]
+          }
+        }
       }
     }
   }

--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -178,10 +178,10 @@ const hasExpandableProperties = computed(() => {
       </CollapsibleTrigger>
       <CollapsibleContent v-if="isObjectOrArray" class="ml-2 pl-2 border-l border-l-solid">
         <Badge
-          v-if="props.property.meta?.isOneOf === true"
+          v-if="props.property.meta?.isOneOf === true || props.property.meta?.isAnyOf === true"
           variant="outline"
         >
-          {{ $t('One of') }}
+          {{ props.property.meta?.isAnyOf === true ? $t('Any of') : $t('One of') }}
         </Badge>
 
         <div class="flex flex-col space-y-2">
@@ -192,7 +192,7 @@ const hasExpandableProperties = computed(() => {
             :schema="props.schema"
             :deep="props.deep - 1"
             :level="props.level + 1"
-            :open="childrenExpandState !== undefined ? childrenExpandState : subProperty?.meta?.isOneOf === true"
+            :open="childrenExpandState !== undefined ? childrenExpandState : (subProperty?.meta?.isOneOf === true || subProperty?.meta?.isAnyOf === true)"
             :expand-all="childrenExpandState"
           />
         </div>

--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useI18n } from '@byjohann/vue-i18n'
 import { ChevronDown, ChevronRight, Maximize2, Minimize2 } from 'lucide-vue-next'
 import { computed, ref, watch } from 'vue'
 import OAMarkdown from '../Common/OAMarkdown.vue'
@@ -35,6 +36,8 @@ const props = defineProps({
   },
 })
 
+const { t } = useI18n()
+
 const isOpen = ref(props.open !== undefined ? props.open : props.deep > 0 && props.level <= 10)
 
 const childrenExpandState = ref(undefined)
@@ -54,12 +57,22 @@ const toggleAllChildren = (expand) => {
 const isObject = props.property.types?.includes('object')
 const isArray = props.property.types?.includes('array')
 const isObjectOrArray = isObject || isArray || props.property.type === 'object' || props.property.type === 'array'
+const isUnion = props.property.meta?.isOneOf === true || props.property.meta?.isAnyOf === true
 
 const hasExpandableProperties = computed(() => {
   return isObjectOrArray
     && props.property.properties
     && props.property.properties.length > 0
     && props.property.properties.some(p => (p.types?.includes('object') || p.types?.includes('array') || p.type === 'object' || p.type === 'array') && p.properties)
+})
+
+const unionBadge = computed(() => {
+  if (props.property.meta?.isOneOf === true) {
+    return t('One of')
+  } else if (props.property.meta?.isAnyOf === true) {
+    return t('Any of')
+  }
+  return ''
 })
 </script>
 
@@ -178,10 +191,10 @@ const hasExpandableProperties = computed(() => {
       </CollapsibleTrigger>
       <CollapsibleContent v-if="isObjectOrArray" class="ml-2 pl-2 border-l border-l-solid">
         <Badge
-          v-if="props.property.meta?.isOneOf === true || props.property.meta?.isAnyOf === true"
+          v-if="isUnion"
           variant="outline"
         >
-          {{ props.property.meta?.isAnyOf === true ? $t('Any of') : $t('One of') }}
+          {{ unionBadge }}
         </Badge>
 
         <div class="flex flex-col space-y-2">
@@ -192,7 +205,7 @@ const hasExpandableProperties = computed(() => {
             :schema="props.schema"
             :deep="props.deep - 1"
             :level="props.level + 1"
-            :open="childrenExpandState !== undefined ? childrenExpandState : (subProperty?.meta?.isOneOf === true || subProperty?.meta?.isAnyOf === true)"
+            :open="childrenExpandState !== undefined ? childrenExpandState : isUnion"
             :expand-all="childrenExpandState"
           />
         </div>

--- a/src/lib/examples/getSchemaUiJson.ts
+++ b/src/lib/examples/getSchemaUiJson.ts
@@ -38,19 +38,27 @@ function uiPropertyToJson(property: OAProperty, useExample: boolean): any {
     }, useExample)
   }
 
+  if (isOneOfProperty(property)) {
+    return resolveOneOfProperty(property, useExample)
+  }
+
+  if (isAnyOfProperty(property)) {
+    return resolveAnyOfProperty(property, useExample)
+  }
+
   if (containsType(property, 'object')) {
-    if (isOneOfProperty(property)) {
-      return resolveOneOfProperty(property, useExample)
-    }
     return uiPropertyObjectToJson(property.properties || [], useExample)
   }
 
-  return {}
+  return getDefaultValueForType(property.types[0] ?? 'string', property.defaultValue)
 }
 
 function uiPropertyArrayToJson(property: OAProperty, useExample: boolean): any {
   if (isOneOfProperty(property)) {
     return [resolveOneOfProperty(property, useExample)]
+  }
+  if (isAnyOfProperty(property)) {
+    return [resolveAnyOfProperty(property, useExample)]
   }
 
   if (property.meta?.hasPrefixItems && property.properties && Array.isArray(property.properties)) {
@@ -159,7 +167,19 @@ function isOneOfProperty(property: OAProperty): boolean {
   return !!property.meta?.isOneOf && Array.isArray(property.properties)
 }
 
+function isAnyOfProperty(property: OAProperty): boolean {
+  return !!property.meta?.isAnyOf && Array.isArray(property.properties)
+}
+
 function resolveOneOfProperty(property: OAProperty, useExample: boolean): any {
+  if (property.properties && property.properties.length > 0) {
+    return uiPropertyToJson(property.properties[0], useExample)
+  } else {
+    return useExample ? getPropertyExample(property) : getDefaultValueForType(property.types[0] ?? 'string', property.defaultValue)
+  }
+}
+
+function resolveAnyOfProperty(property: OAProperty, useExample: boolean): any {
   if (property.properties && property.properties.length > 0) {
     return uiPropertyToJson(property.properties[0], useExample)
   } else {

--- a/src/lib/examples/getSchemaUiJson.ts
+++ b/src/lib/examples/getSchemaUiJson.ts
@@ -39,11 +39,11 @@ function uiPropertyToJson(property: OAProperty, useExample: boolean): any {
   }
 
   if (isOneOfProperty(property)) {
-    return resolveOneOfProperty(property, useExample)
+    return resolveUnionProperty(property, useExample)
   }
 
   if (isAnyOfProperty(property)) {
-    return resolveAnyOfProperty(property, useExample)
+    return resolveUnionProperty(property, useExample)
   }
 
   if (containsType(property, 'object')) {
@@ -55,10 +55,10 @@ function uiPropertyToJson(property: OAProperty, useExample: boolean): any {
 
 function uiPropertyArrayToJson(property: OAProperty, useExample: boolean): any {
   if (isOneOfProperty(property)) {
-    return [resolveOneOfProperty(property, useExample)]
+    return [resolveUnionProperty(property, useExample)]
   }
   if (isAnyOfProperty(property)) {
-    return [resolveAnyOfProperty(property, useExample)]
+    return [resolveUnionProperty(property, useExample)]
   }
 
   if (property.meta?.hasPrefixItems && property.properties && Array.isArray(property.properties)) {
@@ -171,15 +171,7 @@ function isAnyOfProperty(property: OAProperty): boolean {
   return !!property.meta?.isAnyOf && Array.isArray(property.properties)
 }
 
-function resolveOneOfProperty(property: OAProperty, useExample: boolean): any {
-  if (property.properties && property.properties.length > 0) {
-    return uiPropertyToJson(property.properties[0], useExample)
-  } else {
-    return useExample ? getPropertyExample(property) : getDefaultValueForType(property.types[0] ?? 'string', property.defaultValue)
-  }
-}
-
-function resolveAnyOfProperty(property: OAProperty, useExample: boolean): any {
+function resolveUnionProperty(property: OAProperty, useExample: boolean): any {
   if (property.properties && property.properties.length > 0) {
     return uiPropertyToJson(property.properties[0], useExample)
   } else {

--- a/src/lib/examples/getSchemaUiJson.ts
+++ b/src/lib/examples/getSchemaUiJson.ts
@@ -38,11 +38,7 @@ function uiPropertyToJson(property: OAProperty, useExample: boolean): any {
     }, useExample)
   }
 
-  if (isOneOfProperty(property)) {
-    return resolveUnionProperty(property, useExample)
-  }
-
-  if (isAnyOfProperty(property)) {
+  if (isUnionProperty(property)) {
     return resolveUnionProperty(property, useExample)
   }
 
@@ -54,10 +50,7 @@ function uiPropertyToJson(property: OAProperty, useExample: boolean): any {
 }
 
 function uiPropertyArrayToJson(property: OAProperty, useExample: boolean): any {
-  if (isOneOfProperty(property)) {
-    return [resolveUnionProperty(property, useExample)]
-  }
-  if (isAnyOfProperty(property)) {
+  if (isUnionProperty(property)) {
     return [resolveUnionProperty(property, useExample)]
   }
 
@@ -169,6 +162,10 @@ function isOneOfProperty(property: OAProperty): boolean {
 
 function isAnyOfProperty(property: OAProperty): boolean {
   return !!property.meta?.isAnyOf && Array.isArray(property.properties)
+}
+
+function isUnionProperty(property: OAProperty): boolean {
+  return isOneOfProperty(property) || isAnyOfProperty(property)
 }
 
 function resolveUnionProperty(property: OAProperty, useExample: boolean): any {

--- a/src/lib/parser/getSchemaUi.ts
+++ b/src/lib/parser/getSchemaUi.ts
@@ -11,6 +11,8 @@ interface Metadata {
   isAdditionalProperties?: boolean
   isOneOf?: boolean
   isOneOfItem?: boolean
+  isAnyOf?: boolean
+  isAnyOfItem?: boolean
   isConstant?: boolean
   isPrefixItem?: boolean
   prefixItemIndex?: number
@@ -95,18 +97,74 @@ class UiPropertyFactory {
     }
   }
 
-  static createOneOfProperty(oneOfProperties: Partial<OpenAPI.SchemaObject>[], name: string = ''): OAProperty {
-    return {
+  static createOneOfProperty(
+    oneOfProperties: Partial<OpenAPI.SchemaObject>[],
+    name: string = '',
+    baseSchema: Partial<OpenAPI.SchemaObject> = {},
+    required = false,
+  ): OAProperty {
+    const baseProperty = UiPropertyFactory.createBaseProperty(
       name,
-      types: ['object'],
-      required: false,
-      properties: oneOfProperties.map((prop) => {
-        const property = UiPropertyFactory.schemaToUiProperty('', prop)
-        property.meta = { ...(property.meta || {}), isOneOfItem: true }
-        return property
-      }),
-      meta: { isOneOf: true },
+      baseSchema,
+      required,
+    )
+
+    const unionTypes = Array.from(
+      new Set(
+        oneOfProperties
+          .map(prop => determineSchemaType(prop as OpenAPI.SchemaObject))
+          .filter(Boolean),
+      ),
+    ) as JSONSchemaType[]
+
+    if (unionTypes.length > 0) {
+      baseProperty.types = unionTypes
     }
+
+    baseProperty.properties = oneOfProperties.map((prop) => {
+      const property = UiPropertyFactory.schemaToUiProperty('', prop)
+      property.meta = { ...(property.meta || {}), isOneOfItem: true }
+      return property
+    })
+
+    baseProperty.meta = { ...(baseProperty.meta || {}), isOneOf: true }
+
+    return baseProperty
+  }
+
+  static createAnyOfProperty(
+    anyOfProperties: Partial<OpenAPI.SchemaObject>[],
+    name: string = '',
+    baseSchema: Partial<OpenAPI.SchemaObject> = {},
+    required = false,
+  ): OAProperty {
+    const baseProperty = UiPropertyFactory.createBaseProperty(
+      name,
+      baseSchema,
+      required,
+    )
+
+    const unionTypes = Array.from(
+      new Set(
+        anyOfProperties
+          .map(prop => determineSchemaType(prop as OpenAPI.SchemaObject))
+          .filter(Boolean),
+      ),
+    ) as JSONSchemaType[]
+
+    if (unionTypes.length > 0) {
+      baseProperty.types = unionTypes
+    }
+
+    baseProperty.properties = anyOfProperties.map((prop) => {
+      const property = UiPropertyFactory.schemaToUiProperty('', prop)
+      property.meta = { ...(property.meta || {}), isAnyOfItem: true }
+      return property
+    })
+
+    baseProperty.meta = { ...(baseProperty.meta || {}), isAnyOf: true }
+
+    return baseProperty
   }
 
   static schemaToUiProperty(
@@ -127,7 +185,11 @@ class UiPropertyFactory {
     }
 
     if (schema.oneOf) {
-      return UiPropertyFactory.createOneOfProperty(schema.oneOf, name)
+      return UiPropertyFactory.createOneOfProperty(schema.oneOf, name, schema, required)
+    }
+
+    if (schema.anyOf) {
+      return UiPropertyFactory.createAnyOfProperty(schema.anyOf, name, schema, required)
     }
 
     if (schema.const !== undefined) {
@@ -185,6 +247,15 @@ class UiPropertyFactory {
             return {
               ...UiPropertyFactory.schemaToUiProperty('', propSchema),
               meta: { ...(prop.meta || {}), isOneOfItem: true },
+            }
+          })
+        } else if (schema.items.anyOf) {
+          property.meta = { ...(property.meta || {}), isAnyOf: true }
+          property.properties = schema.items.anyOf.map((prop: any) => {
+            const propSchema = { ...prop, type: schema.items.type }
+            return {
+              ...UiPropertyFactory.schemaToUiProperty('', propSchema),
+              meta: { ...(prop.meta || {}), isAnyOfItem: true },
             }
           })
         }

--- a/test/lib/processOpenAPI/getSchemaUi.test.ts
+++ b/test/lib/processOpenAPI/getSchemaUi.test.ts
@@ -367,6 +367,182 @@ const fixtures: Record<string, FixtureTest> = {
     },
   },
 
+  'anyOf schema': {
+    jsonSchema: {
+      anyOf: [
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'integer' },
+          },
+          required: ['name'],
+        },
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'integer' },
+            addresses: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  street: { type: 'string' },
+                },
+              },
+            },
+          },
+          required: ['name'],
+        },
+      ],
+    },
+    schemaUi: {
+      name: '',
+      types: ['object'],
+      properties: [
+        {
+          name: '',
+          properties: [
+            { name: 'name', types: ['string'], required: true },
+            { name: 'age', types: ['integer'], required: false },
+          ],
+          types: ['object'],
+          required: false,
+          meta: {
+            isAnyOfItem: true,
+          },
+        },
+        {
+          name: '',
+          properties: [
+            { name: 'name', types: ['string'], required: true },
+            { name: 'age', types: ['integer'], required: false },
+            {
+              name: 'addresses',
+              properties: [
+                { name: 'street', types: ['string'], required: false },
+              ],
+              required: false,
+              types: ['array'],
+              subtype: 'object',
+            },
+          ],
+          types: ['object'],
+          required: false,
+          meta: {
+            isAnyOfItem: true,
+          },
+        },
+      ],
+      required: false,
+      meta: {
+        isAnyOf: true,
+      },
+    },
+    // Takes first anyOf schema as default.
+    schemaUiJson: {
+      name: 'string',
+      age: 0,
+    },
+  },
+
+  'anyOf schema with description': {
+    jsonSchema: {
+      type: 'object',
+      properties: {
+        foo: {
+          anyOf: [
+            {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
+            {
+              type: 'null',
+            },
+          ],
+          description: 'Some description here...',
+        },
+      },
+      required: ['foo'],
+    },
+    schemaUi: {
+      name: '',
+      types: ['object'],
+      required: false,
+      properties: [
+        {
+          name: 'foo',
+          types: ['array', 'null'],
+          required: true,
+          description: 'Some description here...',
+          properties: [
+            {
+              name: '',
+              types: ['array'],
+              required: false,
+              subtype: 'string',
+              meta: {
+                isAnyOfItem: true,
+              },
+            },
+            {
+              name: '',
+              types: ['null'],
+              required: false,
+              meta: {
+                isAnyOfItem: true,
+              },
+            },
+          ],
+          meta: {
+            isAnyOf: true,
+          },
+        },
+      ],
+    },
+    schemaUiJson: {
+      foo: ['string'],
+    },
+  },
+
+  'required oneOf property': {
+    jsonSchema: {
+      type: 'object',
+      properties: {
+        foo: {
+          oneOf: [
+            { type: 'string' },
+            { type: 'null' },
+          ],
+        },
+      },
+      required: ['foo'],
+    },
+    schemaUi: {
+      name: '',
+      types: ['object'],
+      required: false,
+      properties: [
+        {
+          name: 'foo',
+          types: ['string', 'null'],
+          required: true,
+          properties: [
+            { name: '', types: ['string'], required: false, meta: { isOneOfItem: true } },
+            { name: '', types: ['null'], required: false, meta: { isOneOfItem: true } },
+          ],
+          meta: { isOneOf: true },
+        },
+      ],
+    },
+    schemaUiJson: {
+      foo: 'string',
+    },
+  },
+
   'nested oneOf schema': {
     jsonSchema: {
       oneOf: [


### PR DESCRIPTION
This PR adds support for `anyOf` schemas and improves support for `oneOf` schemas as well.

Consider an OpenAPI spec that uses a schema object like this one:

```yaml
PetWithTag: 
  type: "object"
  properties: 
    pet: 
      description: "Full pet object **or** numeric pet ID"
      oneOf: 
        - $ref: "#/components/schemas/Cat"
        - type: "integer"
          description: "Pet ID"
    tag: 
      description: "Structured tag object **or** plain-text label"
      anyOf: 
        - $ref: "#/components/schemas/TagInfo"
        - type: "string"
          description: "Free-text label"
  required: 
    - "pet"
    - "tag"
```

### Previously, it was rendered as follows:

<img width=500 src=https://github.com/user-attachments/assets/f167e37d-bde4-4d13-960c-0073368ac128 />

Notice the following issues:

* The `tag` display is incomplete: in the schema it is `anyOf` `TagInfo definition` | `string`, but on the page it appears as just `string`.
* Absence of the `Required` label on the `pet` property.
* The type of the `pet` property is shown as just `object`, though the actual type is `object | integer`.
* Missing description for the `pet` property (only the descriptions of the nested schemas are present).

### This PR resolves all these problems. Take a look:

<img width=500 src=https://github.com/user-attachments/assets/ea45a7be-72b8-4ab1-8d8d-1cb8213ace12 />
