### PR TITLE
fix: Crash when `Path Item Object` has a field other than HTTP verb

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,18 @@
+import { OpenAPIV3 } from '@scalar/openapi-types'
+
 export { usePaths } from './composables/usePaths'
 export { useSidebar } from './composables/useSidebar'
 export { OpenApi } from './lib/OpenApi'
 
-export const httpVerbs = ['get', 'post', 'put', 'delete', 'patch', 'options', 'head']
+export const httpVerbs: readonly OpenAPIV3.HttpMethods[] = [
+  OpenAPIV3.HttpMethods.GET,
+  OpenAPIV3.HttpMethods.POST,
+  OpenAPIV3.HttpMethods.PUT,
+  OpenAPIV3.HttpMethods.DELETE,
+  OpenAPIV3.HttpMethods.PATCH,
+  OpenAPIV3.HttpMethods.OPTIONS,
+  OpenAPIV3.HttpMethods.HEAD,
+  OpenAPIV3.HttpMethods.TRACE,
+]
 
 export const literalTypes = ['string', 'number', 'integer', 'boolean', 'null']

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,15 +4,6 @@ export { usePaths } from './composables/usePaths'
 export { useSidebar } from './composables/useSidebar'
 export { OpenApi } from './lib/OpenApi'
 
-export const httpVerbs: readonly OpenAPIV3.HttpMethods[] = [
-  OpenAPIV3.HttpMethods.GET,
-  OpenAPIV3.HttpMethods.POST,
-  OpenAPIV3.HttpMethods.PUT,
-  OpenAPIV3.HttpMethods.DELETE,
-  OpenAPIV3.HttpMethods.PATCH,
-  OpenAPIV3.HttpMethods.OPTIONS,
-  OpenAPIV3.HttpMethods.HEAD,
-  OpenAPIV3.HttpMethods.TRACE,
-]
+export const httpVerbs: readonly OpenAPIV3.HttpMethods[] = Object.values(OpenAPIV3.HttpMethods)
 
 export const literalTypes = ['string', 'number', 'integer', 'boolean', 'null']

--- a/src/lib/parser/generateCodeSamples.ts
+++ b/src/lib/parser/generateCodeSamples.ts
@@ -1,6 +1,6 @@
-import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type { OAExampleObject, ParsedOpenAPI, ParsedOperation, PlaygroundSecurityScheme } from '../../types'
 import { availableLanguages, useTheme } from '../../composables/useTheme'
+import { httpVerbs } from '../../index'
 import { buildRequest } from '../codeSamples/buildRequest'
 import { generateCodeSample } from '../codeSamples/generateCodeSample'
 import { resolveBaseUrl } from '../resolveBaseUrl'
@@ -13,8 +13,8 @@ export async function generateCodeSamples(spec: ParsedOpenAPI): Promise<ParsedOp
   const baseUrl = resolveBaseUrl(spec.servers?.[0]?.url || '')
 
   for (const [path, pathObject] of Object.entries(spec.paths)) {
-    for (const verb of Object.keys(pathObject) as OpenAPIV3.HttpMethods[]) {
-      const operation = pathObject[verb] as ParsedOperation
+    for (const verb of httpVerbs) {
+      const operation = (pathObject as Record<string, any>)[verb] as ParsedOperation
 
       if (!operation) {
         continue

--- a/src/lib/parser/generateMissingOperationIds.ts
+++ b/src/lib/parser/generateMissingOperationIds.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type { OpenAPIDocument } from '../../types'
+import { httpVerbs } from '../../index'
 
 export function generateMissingOperationIds(spec: OpenAPIDocument): OpenAPIDocument {
   spec.paths = spec.paths || {}
@@ -7,8 +8,12 @@ export function generateMissingOperationIds(spec: OpenAPIDocument): OpenAPIDocum
   for (const path of Object.keys(spec.paths)) {
     const pathValue = spec.paths[path] as Record<string, OpenAPIV3.OperationObject>
 
-    for (const verb of Object.keys(pathValue) as OpenAPIV3.HttpMethods[]) {
+    for (const verb of httpVerbs) {
       const operation = pathValue[verb]
+
+      if (!operation) {
+        continue
+      }
 
       if (!operation.operationId) {
         operation.operationId = `${verb}${path.replace(/\//g, '-')}`

--- a/src/lib/parser/generateMissingSummary.ts
+++ b/src/lib/parser/generateMissingSummary.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type { OpenAPIDocument, OperationObject } from '../../types'
+import { httpVerbs } from '../../index'
 
 export function generateMissingSummary(spec: OpenAPIDocument): OpenAPIDocument {
   spec.paths = spec.paths || {}
@@ -7,8 +8,12 @@ export function generateMissingSummary(spec: OpenAPIDocument): OpenAPIDocument {
   for (const path of Object.keys(spec.paths)) {
     const pathValue = spec.paths[path] as Record<string, OperationObject>
 
-    for (const verb of Object.keys(pathValue) as OpenAPIV3.HttpMethods[]) {
+    for (const verb of httpVerbs) {
       const operation = pathValue[verb] as OperationObject
+
+      if (!operation) {
+        continue
+      }
 
       if (!operation.summary) {
         operation.summary = `${verb.toUpperCase()} ${path}`

--- a/src/lib/parser/generateMissingSummary.ts
+++ b/src/lib/parser/generateMissingSummary.ts
@@ -1,4 +1,3 @@
-import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type { OpenAPIDocument, OperationObject } from '../../types'
 import { httpVerbs } from '../../index'
 

--- a/src/lib/parser/generateMissingTags.ts
+++ b/src/lib/parser/generateMissingTags.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type { OpenAPIDocument } from '../../types'
+import { httpVerbs } from '../../index'
 
 export function generateMissingTags({
   spec,
@@ -14,8 +15,8 @@ export function generateMissingTags({
 
   spec.paths = spec.paths || {}
 
-  for (const [_, pathObject] of Object.entries(spec.paths)) {
-    for (const verb of Object.keys(pathObject as any) as OpenAPIV3.HttpMethods[]) {
+  for (const [, pathObject] of Object.entries(spec.paths)) {
+    for (const verb of httpVerbs) {
       if (!pathObject || !pathObject[verb]) {
         continue
       }

--- a/src/lib/parser/generateMissingTags.ts
+++ b/src/lib/parser/generateMissingTags.ts
@@ -1,4 +1,3 @@
-import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type { OpenAPIDocument } from '../../types'
 import { httpVerbs } from '../../index'
 

--- a/src/lib/parser/generateRequestBodyUi.ts
+++ b/src/lib/parser/generateRequestBodyUi.ts
@@ -1,6 +1,7 @@
 import type { ParsedContent, ParsedOpenAPI, ParsedOperation } from '../../types'
 import { getSchemaExample } from '../examples/getSchemaExample'
 import { getSchemaUi } from './getSchemaUi'
+import { httpVerbs } from '../../index'
 
 export function generateRequestBodyUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   if (!spec.paths) {
@@ -8,9 +9,12 @@ export function generateRequestBodyUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   }
 
   for (const path of Object.values(spec.paths)) {
-    for (const verb of Object.keys(path)) {
-      const operation = path[verb] as ParsedOperation
+    for (const verb of httpVerbs) {
+      const operation = (path as Record<string, any>)[verb] as ParsedOperation
 
+      if (!operation) {
+        continue
+      }
       if (!operation.requestBody) {
         continue
       }

--- a/src/lib/parser/generateRequestBodyUi.ts
+++ b/src/lib/parser/generateRequestBodyUi.ts
@@ -15,6 +15,7 @@ export function generateRequestBodyUi(spec: ParsedOpenAPI): ParsedOpenAPI {
       if (!operation) {
         continue
       }
+
       if (!operation.requestBody) {
         continue
       }

--- a/src/lib/parser/generateRequestBodyUi.ts
+++ b/src/lib/parser/generateRequestBodyUi.ts
@@ -1,7 +1,7 @@
 import type { ParsedContent, ParsedOpenAPI, ParsedOperation } from '../../types'
+import { httpVerbs } from '../../index'
 import { getSchemaExample } from '../examples/getSchemaExample'
 import { getSchemaUi } from './getSchemaUi'
-import { httpVerbs } from '../../index'
 
 export function generateRequestBodyUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   if (!spec.paths) {

--- a/src/lib/parser/generateResponseUi.ts
+++ b/src/lib/parser/generateResponseUi.ts
@@ -1,6 +1,7 @@
 import type { ParsedContent, ParsedOpenAPI, ParsedOperation } from '../../types'
 import { getSchemaExample } from '../examples/getSchemaExample'
 import { getSchemaUi } from './getSchemaUi'
+import { httpVerbs } from '../../index'
 
 export function generateResponseUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   if (!spec.paths) {
@@ -8,9 +9,12 @@ export function generateResponseUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   }
 
   for (const path of Object.values(spec.paths)) {
-    for (const verb of Object.keys(path)) {
-      const operation = path[verb] as ParsedOperation
+    for (const verb of httpVerbs) {
+      const operation = (path as Record<string, any>)[verb] as ParsedOperation
 
+      if (!operation) {
+        continue
+      }
       if (!operation.responses) {
         continue
       }

--- a/src/lib/parser/generateResponseUi.ts
+++ b/src/lib/parser/generateResponseUi.ts
@@ -1,7 +1,7 @@
 import type { ParsedContent, ParsedOpenAPI, ParsedOperation } from '../../types'
+import { httpVerbs } from '../../index'
 import { getSchemaExample } from '../examples/getSchemaExample'
 import { getSchemaUi } from './getSchemaUi'
-import { httpVerbs } from '../../index'
 
 export function generateResponseUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   if (!spec.paths) {

--- a/src/lib/parser/generateResponseUi.ts
+++ b/src/lib/parser/generateResponseUi.ts
@@ -15,6 +15,7 @@ export function generateResponseUi(spec: ParsedOpenAPI): ParsedOpenAPI {
       if (!operation) {
         continue
       }
+
       if (!operation.responses) {
         continue
       }

--- a/src/lib/parser/generateSecurityUi.ts
+++ b/src/lib/parser/generateSecurityUi.ts
@@ -1,6 +1,7 @@
 import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type { ParsedOpenAPI, ParsedOperation } from '../../types'
 import { getSecurityUi } from './getSecurityUi'
+import { httpVerbs } from '../../index'
 
 export function generateSecurityUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   if (!spec?.paths) {
@@ -8,13 +9,12 @@ export function generateSecurityUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   }
 
   for (const path of Object.values(spec.paths)) {
-    for (const verb of Object.keys(path) as OpenAPIV3.HttpMethods[]) {
-      const operation = path[verb] as ParsedOperation
+    for (const verb of httpVerbs) {
+      const operation = (path as Record<string, any>)[verb] as ParsedOperation
 
       if (!operation) {
         continue
       }
-
       operation.securityUi = getSecurityUi(operation.security ?? spec.security ?? [], spec.components?.securitySchemes || {})
     }
   }

--- a/src/lib/parser/generateSecurityUi.ts
+++ b/src/lib/parser/generateSecurityUi.ts
@@ -14,6 +14,7 @@ export function generateSecurityUi(spec: ParsedOpenAPI): ParsedOpenAPI {
       if (!operation) {
         continue
       }
+
       operation.securityUi = getSecurityUi(operation.security ?? spec.security ?? [], spec.components?.securitySchemes || {})
     }
   }

--- a/src/lib/parser/generateSecurityUi.ts
+++ b/src/lib/parser/generateSecurityUi.ts
@@ -1,7 +1,6 @@
-import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type { ParsedOpenAPI, ParsedOperation } from '../../types'
-import { getSecurityUi } from './getSecurityUi'
 import { httpVerbs } from '../../index'
+import { getSecurityUi } from './getSecurityUi'
 
 export function generateSecurityUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   if (!spec?.paths) {

--- a/test/lib/prepareOpenAPI/generateMissingOperationIds.test.ts
+++ b/test/lib/prepareOpenAPI/generateMissingOperationIds.test.ts
@@ -67,4 +67,22 @@ describe('generateMissingOperationIds', () => {
     const result = generateMissingOperationIds(input)
     expect(result).toEqual(input)
   })
+
+  it('ignores non-verb fields in path objects', () => {
+    const input = {
+      paths: {
+        '/example': {
+          summary: 'Example endpoint',
+          description: 'More info',
+          get: {},
+        },
+      },
+    }
+
+    const result = generateMissingOperationIds(input)
+
+    expect(result.paths['/example'].summary).toBe('Example endpoint')
+    expect(result.paths['/example'].description).toBe('More info')
+    expect(result.paths['/example'].get.operationId).toBe('get-example')
+  })
 })

--- a/test/lib/prepareOpenAPI/generateMissingSummary.test.ts
+++ b/test/lib/prepareOpenAPI/generateMissingSummary.test.ts
@@ -53,4 +53,22 @@ describe('generateMissingSummary', () => {
     const result = generateMissingSummary(value)
     expect(result.paths).toEqual({})
   })
+
+  it('ignores non-verb fields in path objects', () => {
+    const value = {
+      paths: {
+        '/item': {
+          summary: 'Item summary',
+          description: 'desc',
+          get: {},
+        },
+      },
+    }
+
+    const result = generateMissingSummary(value)
+
+    expect(result.paths['/item'].summary).toBe('Item summary')
+    expect(result.paths['/item'].description).toBe('desc')
+    expect(result.paths['/item'].get.summary).toBe('GET /item')
+  })
 })

--- a/test/lib/prepareOpenAPI/generateMissingTags.test.ts
+++ b/test/lib/prepareOpenAPI/generateMissingTags.test.ts
@@ -92,4 +92,17 @@ describe('generateMissingTags', () => {
       description: 'Custom Description',
     }])
   })
+  it('ignores non-verb fields in path objects', () => {
+    const spec = {
+      paths: {
+        '/example': {
+          summary: 'Some summary',
+          get: {},
+        },
+      },
+    }
+    const result = generateMissingTags({ spec })
+    expect(result.paths['/example'].summary).toBe('Some summary')
+    expect(result.paths['/example'].get.tags).toEqual(['Default'])
+  })
 })

--- a/test/lib/prepareOpenAPI/generateMissingTags.test.ts
+++ b/test/lib/prepareOpenAPI/generateMissingTags.test.ts
@@ -92,6 +92,7 @@ describe('generateMissingTags', () => {
       description: 'Custom Description',
     }])
   })
+
   it('ignores non-verb fields in path objects', () => {
     const spec = {
       paths: {

--- a/test/lib/processOpenAPI/parseOpenapi.pathMetadata.test.ts
+++ b/test/lib/processOpenAPI/parseOpenapi.pathMetadata.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { parseOpenapi } from '../../../src/lib/parser/parseOpenapi'
+
+const spec = {
+  openapi: '3.0.0',
+  info: { title: 'Test', version: '1.0.0' },
+  paths: {
+    '/example': {
+      summary: 'Example summary',
+      description: 'Example description',
+      get: {
+        responses: {
+          '200': { description: 'OK' },
+        },
+      },
+    },
+  },
+}
+
+describe('parseOpenapi with path metadata', () => {
+  it('processes paths containing summary or description', () => {
+    const result = parseOpenapi().parseSync({ spec })
+    expect(result.paths['/example'].summary).toBe('Example summary')
+    expect(result.paths['/example'].description).toBe('Example description')
+    expect(result.paths['/example'].get.operationId).toBe('get-example')
+    expect(result.paths['/example'].get.summary).toBe('GET /example')
+  })
+})

--- a/test/lib/processOpenAPI/parseOpenapi.pathMetadata.test.ts
+++ b/test/lib/processOpenAPI/parseOpenapi.pathMetadata.test.ts
@@ -10,7 +10,7 @@ const spec = {
       description: 'Example description',
       get: {
         responses: {
-          '200': { description: 'OK' },
+          200: { description: 'OK' },
         },
       },
     },


### PR DESCRIPTION
OpenAPI spec allows metadata fields like `summary` or `description` at the Path Item Object level: https://spec.openapis.org/oas/v3.0.4.html#path-item-object.

However, a spec like the one below leads to a crash due to the incorrect assumption that all keys of a Path Item Object are HTTP verbs / objects:

```yaml
openapi: "3.0.0"
info: 
  title: "Minimal API"
  version: "1.0.0"
paths: 
  /example: 
    summary: "Example endpoint"
    description: "This path supports both GET and POST methods."
    get: 
      responses: 
        200: 
          description: "OK"
    post: 
      responses: 
        201: 
          description: "Created"
```

This produced the following error:

```
TypeError: Cannot create property 'operationId' on string 'This path supports both GET and POST methods.'
```

### With this fix:

* Parser utilities now iterate only over supported HTTP verbs (now defined via the official OpenAPI enum), preventing accidental processing of path-level metadata such as `summary` or `description` fields.
* Path tag generation respects the same verb filtering to avoid treating strings as operations.
* Request/response handling and security helpers also use this filtered iteration to correctly build UI data.
* Code sample generation imports the HTTP verb list to iterate safely over valid methods only.
* New test cases ensure that path item metadata does not interfere with parsing logic.

### Note:
This fix only prevents hard crashes when metadata fields are present at the path level. It doesn't make `description` and `summary` from the path level to be rendered in the UI, as I see no obvious place to display them neatly - and this is a design decision left to @enzonotario. We should probably open an issue about adding support for this and work on it separately.