### PR TITLE
fix: overflow of long unbreakable text in 'servers' block

### DIFF
--- a/src/components/Feature/OAServersContent.vue
+++ b/src/components/Feature/OAServersContent.vue
@@ -18,7 +18,7 @@ const servers = props.openapi.spec.servers ?? []
     </OAHeading>
 
     <div class="flex flex-col space-y-4">
-      <div v-for="server in servers" :key="server.url" class="flex flex-col p-3 gap-2 rounded bg-muted overflow-auto">
+      <div v-for="server in servers" :key="server.url" class="flex flex-col p-3 gap-2 rounded bg-muted overflow-x-auto">
         <span class="font-semibold select-all">
           {{ server.url }}
         </span>

--- a/src/components/Feature/OAServersContent.vue
+++ b/src/components/Feature/OAServersContent.vue
@@ -18,7 +18,7 @@ const servers = props.openapi.spec.servers ?? []
     </OAHeading>
 
     <div class="flex flex-col space-y-4">
-      <div v-for="server in servers" :key="server.url" class="flex flex-col p-3 gap-2 rounded bg-muted">
+      <div v-for="server in servers" :key="server.url" class="flex flex-col p-3 gap-2 rounded bg-muted overflow-auto">
         <span class="font-semibold select-all">
           {{ server.url }}
         </span>


### PR DESCRIPTION
This PR fixes text overflow in the "servers" block when the text contains long, unbreakable words like long URLs or similar content.

Before:

<img width=300px src=https://github.com/user-attachments/assets/b06091bb-5106-4020-9750-30be2ba7b9c9 >

After:

<img width=300px src=https://github.com/user-attachments/assets/19488d2e-783a-4594-a799-732b44be23b3 >
