### PR TITLE
feat: improve UI for default values and enums

### DIFF
--- a/src/components/Common/OACodeValue.vue
+++ b/src/components/Common/OACodeValue.vue
@@ -2,6 +2,12 @@
 const { value } = defineProps({
   value: [String, Number, Boolean, Array, Object],
 })
+
+const getDisplayValue = (value) => {
+  // We run JSON.stringify on everything except objects (which Vue handles better)
+  // to distinguish `"null"` from `null`, `"1"` from `1`, etc.
+  return value && typeof value === 'object' ? value : JSON.stringify(value)
+}
 </script>
 
 <template>
@@ -11,12 +17,11 @@ const { value } = defineProps({
       :key="attributeIdx"
       class="!text-xs text-wrap break-all"
     >
-      {{ item }}
+      {{ getDisplayValue(item) }}
     </code>
   </template>
-  <code
-    v-else class="!text-xs text-wrap break-all"
-  >
-    {{ value }}
+
+  <code v-else class="!text-xs text-wrap break-all">
+    {{ getDisplayValue(value) }}
   </code>
 </template>

--- a/src/components/Schema/OASchemaPropertyAttributes.vue
+++ b/src/components/Schema/OASchemaPropertyAttributes.vue
@@ -26,7 +26,7 @@ const isNonEmptyValue = (value) => {
 
 const properties = Object.keys(props.property)
   .filter(key => !keysToIgnore.includes(key)) // Exclude specified keys
-  .filter(key => isNonEmptyValue(props.property[key])) // Keep only non-empty values
+  .filter(key => isNonEmptyValue(props.property[key]) || (key === 'default' && key !== undefined)) // Keep only non-empty values except for "default"
 </script>
 
 <template>

--- a/src/components/Schema/OASchemaPropertyAttributes.vue
+++ b/src/components/Schema/OASchemaPropertyAttributes.vue
@@ -26,7 +26,7 @@ const isNonEmptyValue = (value) => {
 
 const properties = Object.keys(props.property)
   .filter(key => !keysToIgnore.includes(key)) // Exclude specified keys
-  .filter(key => isNonEmptyValue(props.property[key]) || (key === 'default' && key !== undefined)) // Keep only non-empty values except for "default"
+  .filter(key => isNonEmptyValue(props.property[key]) || (key === 'default' && props.property[key] !== undefined)) // Keep only non-empty values except for "default"
 </script>
 
 <template>

--- a/src/lib/parser/getSchemaUi.ts
+++ b/src/lib/parser/getSchemaUi.ts
@@ -206,13 +206,10 @@ class UiPropertyFactory {
         types = ['string']
       }
 
-      return {
-        name,
-        types,
-        required: false,
-        enum: schema.enum,
-        description: schema.description,
-      }
+      const property = UiPropertyFactory.createBaseProperty(name, schema, required)
+      property.enum = schema.enum
+      property.types = types
+      return property
     }
 
     const property = UiPropertyFactory.createBaseProperty(name, schema, required)

--- a/src/lib/parser/getSchemaUi.ts
+++ b/src/lib/parser/getSchemaUi.ts
@@ -191,10 +191,24 @@ class UiPropertyFactory {
       }
     }
 
-    if (literalTypes.includes(String(schema.type)) && schema.enum) {
+    if (schema.enum) {
+      let types: JSONSchemaType[] = []
+
+      if (schema.type) {
+        types = Array.isArray(schema.type)
+          ? schema.type as JSONSchemaType[]
+          : [schema.type as JSONSchemaType]
+      } else {
+        types = inferTypesFromEnum(schema.enum)
+      }
+
+      if (types.length === 0) {
+        types = ['string']
+      }
+
       return {
         name,
-        types: [schema.type as JSONSchemaType],
+        types,
         required: false,
         enum: schema.enum,
         description: schema.description,
@@ -348,6 +362,28 @@ export function getSchemaUi(jsonSchema: OpenAPI.SchemaObject): OAProperty | OAPr
   const resolvedSchema = resolveCircularRef(jsonSchema)
 
   return UiPropertyFactory.schemaToUiProperty('', resolvedSchema)
+}
+
+function inferTypesFromEnum(values: unknown[]): JSONSchemaType[] {
+  const types = new Set<JSONSchemaType>()
+
+  values.forEach((value) => {
+    if (value === null) {
+      types.add('null')
+    } else if (Array.isArray(value)) {
+      types.add('array')
+    } else if (typeof value === 'object') {
+      types.add('object')
+    } else if (typeof value === 'string') {
+      types.add('string')
+    } else if (typeof value === 'boolean') {
+      types.add('boolean')
+    } else if (typeof value === 'number') {
+      types.add(Number.isInteger(value) ? 'integer' : 'number')
+    }
+  })
+
+  return Array.from(types)
 }
 
 function determineSchemaType(schema: OpenAPI.SchemaObject): JSONSchemaType {

--- a/src/lib/parser/getSchemaUi.ts
+++ b/src/lib/parser/getSchemaUi.ts
@@ -1,5 +1,4 @@
 import type { OpenAPI } from '@scalar/openapi-types'
-import { literalTypes } from '../../index'
 import { getPropertyExamples } from '../examples/getPropertyExamples'
 import { getConstraints, hasConstraints } from './constraintsParser'
 import { resolveCircularRef } from './resolveCircularRef'

--- a/src/lib/parser/getSchemaUi.ts
+++ b/src/lib/parser/getSchemaUi.ts
@@ -380,6 +380,10 @@ function inferTypesFromEnum(values: unknown[]): JSONSchemaType[] {
     }
   })
 
+  if (types.has('number')) {
+    types.delete('integer')
+  }
+
   return Array.from(types)
 }
 

--- a/test/lib/processOpenAPI/getSchemaUi.test.ts
+++ b/test/lib/processOpenAPI/getSchemaUi.test.ts
@@ -127,6 +127,46 @@ const fixtures: Record<string, FixtureTest> = {
     schemaUiJson: 'string',
   },
 
+  'schema with enum without explicit type': {
+    jsonSchema: {
+      enum: ['red', 'amber', 'green'],
+    },
+    schemaUi: {
+      name: '',
+      types: ['string'],
+      required: false,
+      enum: ['red', 'amber', 'green'],
+    },
+    schemaUiJson: 'string',
+  },
+
+  'schema with enum mixed types': {
+    jsonSchema: {
+      enum: ['red', 'amber', 'green', false, null, 42],
+    },
+    schemaUi: {
+      name: '',
+      types: ['string', 'boolean', 'null', 'integer'],
+      required: false,
+      enum: ['red', 'amber', 'green', false, null, 42],
+    },
+    schemaUiJson: 'string',
+  },
+
+  'schema with enum and defined types': {
+    jsonSchema: {
+      type: ['string', 'number'],
+      enum: ['red', 42],
+    },
+    schemaUi: {
+      name: '',
+      types: ['string', 'number'],
+      required: false,
+      enum: ['red', 42],
+    },
+    schemaUiJson: 'string',
+  },
+
   'deep array schema': {
     jsonSchema: {
       type: 'array',

--- a/test/lib/processOpenAPI/getSchemaUi.test.ts
+++ b/test/lib/processOpenAPI/getSchemaUi.test.ts
@@ -163,7 +163,7 @@ const fixtures: Record<string, FixtureTest> = {
       required: false,
       enum: [42, 42.1],
     },
-    schemaUiJson: 'string',
+    schemaUiJson: 0,
   },
 
   'schema with enum and defined types': {

--- a/test/lib/processOpenAPI/getSchemaUi.test.ts
+++ b/test/lib/processOpenAPI/getSchemaUi.test.ts
@@ -1533,6 +1533,49 @@ const fixtures: Record<string, FixtureTest> = {
     },
   },
 
+  'enum with default value': {
+    jsonSchema: {
+      type: 'string',
+      enum: ['cat', 'dog'],
+      default: 'cat',
+    },
+    schemaUi: {
+      name: '',
+      types: ['string'],
+      required: false,
+      enum: ['cat', 'dog'],
+      constraints: { default: 'cat' },
+      defaultValue: 'cat',
+    },
+    schemaUiJson: 'cat',
+  },
+
+  'object with null default': {
+    jsonSchema: {
+      type: 'object',
+      properties: {
+        hasFur: { type: ['boolean', 'null'], default: null },
+      },
+    },
+    schemaUi: {
+      name: '',
+      properties: [
+        {
+          name: 'hasFur',
+          required: false,
+          types: ['boolean', 'null'],
+          constraints: { default: null },
+          defaultValue: null,
+        },
+      ],
+      types: ['object'],
+      required: false,
+    },
+    schemaUiJson: {
+      hasFur: null,
+    },
+  },
+
   'object nullable': {
     jsonSchema: {
       type: ['object', 'null'],

--- a/test/lib/processOpenAPI/getSchemaUi.test.ts
+++ b/test/lib/processOpenAPI/getSchemaUi.test.ts
@@ -140,15 +140,28 @@ const fixtures: Record<string, FixtureTest> = {
     schemaUiJson: 'string',
   },
 
-  'schema with enum mixed types': {
+  'schema with mixed enum without explicit type': {
     jsonSchema: {
-      enum: ['red', 'amber', 'green', false, null, 42],
+      enum: ['red', 'amber', 'green', false, null, 42, 42.0],
     },
     schemaUi: {
       name: '',
       types: ['string', 'boolean', 'null', 'integer'],
       required: false,
-      enum: ['red', 'amber', 'green', false, null, 42],
+      enum: ['red', 'amber', 'green', false, null, 42, 42.0],
+    },
+    schemaUiJson: 'string',
+  },
+
+  'schema with mixed integer+number enum without explicit type': {
+    jsonSchema: {
+      enum: [42, 42.1],
+    },
+    schemaUi: {
+      name: '',
+      types: ['number'],
+      required: false,
+      enum: [42, 42.1],
     },
     schemaUiJson: 'string',
   },


### PR DESCRIPTION
This improves UI display of enums and default values, as well as enums with default values.

### Consider schemas like this:

```json
"components": {
  "schemas": {
    "Pet": {
      "type": "object",
      "properties": {
        "petType": {
          "type": "string",
          "enum": ["cat", "dog", "lizard"],
          "default": "cat"
        },
        "hasFur": {
          "type": ["boolean", "null"],
          "default": null
        },
        "paws": {
          "type": "number",
          "default": 4
        },
        "classifierCode": {
          "type": "string",
          "default": "4"
        },
        "color": {
          "enum": ["red", "amber", "green", false, 42, "42", null]
        }
      }
    }
  }
}
```

### Now it is rendered as follows:

<img width=600 src=https://github.com/user-attachments/assets/a9322451-6b1b-4269-b457-2fbc90c48678 >

There are a few problems:

* No default value for `petType` (root cause - because it is an **enum**)
* No default value for `hasFur` (root cause - because its `"default"` is `null` — see [here](https://github.com/OAI/OpenAPI-Specification/issues/2057) the discussion about `null` default values in OA 3.0 if interested)
* Values of type number and string are rendered indistinguishably. Notice that `paws` and `classifierCode` are both shown as `4`, whereas it would be much clearer if the numeric was `4` and the string was `"4"` (especially important when displaying enum "valid values" — see next point)
* `color` renders incorrectly: the UI says it is a `string`, while it's actually something more complex:

  ```json
  "color": {
    "enum": ["red", "amber", "green", false, 42, "42", null]
  }
  ```

  See [here](https://json-schema.org/understanding-json-schema/reference/enum) for why this is valid in the latest JSON Schema drafts.

### This PR solves all of the above, making such an object look like this:

<img width=600 src=https://github.com/user-attachments/assets/3e36c125-65fb-4dfb-bef8-3a3b6063fc2b >