### PR TITLE
fix: respect OpenAPI servers precedence rules

### DIFF
--- a/src/lib/OpenApi.ts
+++ b/src/lib/OpenApi.ts
@@ -158,11 +158,15 @@ export function OpenApi({
 
     const pathServers = paths[(operationPath ?? '')]?.servers
 
-    return [
-      ...(operation?.servers ?? []),
-      ...(pathServers ?? []),
-      ...(getSpec().servers ?? []),
-    ]
+    if (operation?.servers !== undefined) {
+      return operation.servers as OpenAPIV3.ServerObject[]
+    }
+
+    if (pathServers !== undefined) {
+      return pathServers as OpenAPIV3.ServerObject[]
+    }
+
+    return getSpec().servers ?? []
   }
 
   function getOperationsTags(): string[] {

--- a/test/composables/openapi.test.ts
+++ b/test/composables/openapi.test.ts
@@ -237,7 +237,6 @@ describe('openapi with spec', () => {
     const result = openapi.getOperationServers('getUsers')
     expect(result).toEqual([
       ...spec.paths['/users'].get.servers,
-      ...spec.servers,
     ])
   })
 })
@@ -294,18 +293,12 @@ describe('spec with different servers for specific path', () => {
       {
         url: 'https://api.path.com',
       },
-      {
-        url: 'https://api.example.com',
-      },
     ])
 
     const useLocalServer = openapi.getOperationServers('useLocalServer')
     expect(useLocalServer).toEqual([
       {
         url: 'https://api.local.com',
-      },
-      {
-        url: 'https://api.example.com',
       },
     ])
   })


### PR DESCRIPTION
According to the OpenAPI specification (3.1, 3.0, and earlier), the ["servers" field in the Path Item Object](https://spec.openapis.org/oas/latest.html#path-item-object), as well as in the [Operation Object](https://spec.openapis.org/oas/latest.html#operation-object), overrides (not merges with) any servers defined at higher levels.

This PR updates the `OpenApi` lib function to respect that specification and ensures that when "servers" are defined at both the OpenAPI Object level and the _Path_ and/or _Operation_ level, the lower-level "servers" take precedence and override the higher-level ones.