### PR TITLE
fix: render sidebar items with multiple tags in all groups

### DIFF
--- a/test/composables/useSidebar.multipleTags.test.ts
+++ b/test/composables/useSidebar.multipleTags.test.ts
@@ -70,7 +70,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/findCat',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/findCat',
+              path: '/api/cats',
               title: 'Find a cat',
             }),
           },
@@ -78,7 +78,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/findSphynx',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/findSphynx',
+              path: '/api/sphynxs',
               title: 'Find a sphynx cat',
             }),
           },
@@ -86,7 +86,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/findFancyRat',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/findFancyRat',
+              path: '/api/fancyrats',
               title: 'Find a fancy rat',
             }),
           },
@@ -99,7 +99,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/findCat',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/findCat',
+              path: '/api/cats',
               title: 'Find a cat',
             }),
           },
@@ -107,7 +107,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/findSphynx',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/findSphynx',
+              path: '/api/sphynxs',
               title: 'Find a sphynx cat',
             }),
           },
@@ -120,7 +120,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/findCat',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/findCat',
+              path: '/api/cats',
               title: 'Find a cat',
             }),
           },
@@ -128,7 +128,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/findFancyRat',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/findFancyRat',
+              path: '/api/fancyrats',
               title: 'Find a fancy rat',
             }),
           },
@@ -141,7 +141,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/findSphynx',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/findSphynx',
+              path: '/api/sphynxs',
               title: 'Find a sphynx cat',
             }),
           },
@@ -154,7 +154,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/findFancyRat',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/findFancyRat',
+              path: '/api/fancyrats',
               title: 'Find a fancy rat',
             }),
           },
@@ -162,7 +162,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/findLizard',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/findLizard',
+              path: '/api/lizards',
               title: 'Find a lizard',
             }),
           },
@@ -175,7 +175,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/findFancyRat',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/findFancyRat',
+              path: '/api/fancyrats',
               title: 'Find a fancy rat',
             }),
           },
@@ -188,7 +188,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/findLizard',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/findLizard',
+              path: '/api/lizards',
               title: 'Find a lizard',
             }),
           },
@@ -201,7 +201,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/findLizard',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/findLizard',
+              path: '/api/lizards',
               title: 'Find a lizard',
             }),
           },
@@ -214,7 +214,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/accountStats',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/accountStats',
+              path: '/account/stats',
               title: 'Get user stats',
             }),
           },
@@ -222,7 +222,7 @@ describe('generateSidebarGroups with operations having multiple tags', () => {
             link: '/operations/checkStatus',
             text: sidebar.sidebarItemTemplate({
               method: 'get',
-              path: '/checkStatus',
+              path: '/status',
               title: 'Check status',
             }),
           },

--- a/test/composables/useSidebar.multipleTags.test.ts
+++ b/test/composables/useSidebar.multipleTags.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest'
+import { useSidebar } from '../../src/composables/useSidebar'
+
+const spec = {
+  openapi: '3.0.4',
+  info: {
+    title: 'Animals API',
+    version: '0.1.0',
+  },
+  paths: {
+    '/api/cats': {
+      get: {
+        tags: ['mammal', 'cat', 'fluffy'],
+        summary: 'Find a cat',
+        operationId: 'findCat',
+        responses: { 200: { description: 'OK' } },
+      },
+    },
+    '/api/sphynxs': {
+      get: {
+        tags: ['mammal', 'cat', 'bald'],
+        summary: 'Find a sphynx cat',
+        operationId: 'findSphynx',
+        responses: { 200: { description: 'OK' } },
+      },
+    },
+    '/api/fancyrats': {
+      get: {
+        tags: ['mammal', 'fluffy', 'small', 'rat'],
+        summary: 'Find a fancy rat',
+        operationId: 'findFancyRat',
+        responses: { 200: { description: 'OK' } },
+      },
+    },
+    '/api/lizards': {
+      get: {
+        tags: ['small', 'reptile', 'lizard'],
+        summary: 'Find a lizard',
+        operationId: 'findLizard',
+        responses: { 200: { description: 'OK' } },
+      },
+    },
+    '/account/stats': {
+      get: {
+        summary: 'Get user stats',
+        operationId: 'accountStats',
+        responses: { 200: { description: 'OK' } },
+      },
+    },
+    '/status': {
+      get: {
+        summary: 'Check status',
+        operationId: 'checkStatus',
+        responses: { 200: { description: 'OK' } },
+      },
+    },
+  },
+}
+
+describe('generateSidebarGroups with operations having multiple tags', () => {
+  const sidebar = useSidebar({ spec })
+
+  it('omits empty groups when grouping by tags', () => {
+    const result = sidebar.generateSidebarGroups()
+    expect(result).toEqual([
+      {
+        text: 'mammal',
+        items: [
+          {
+            link: '/operations/findCat',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/findCat',
+              title: 'Find a cat',
+            }),
+          },
+          {
+            link: '/operations/findSphynx',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/findSphynx',
+              title: 'Find a sphynx cat',
+            }),
+          },
+          {
+            link: '/operations/findFancyRat',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/findFancyRat',
+              title: 'Find a fancy rat',
+            }),
+          },
+        ],
+      },
+      {
+        text: 'cat',
+        items: [
+          {
+            link: '/operations/findCat',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/findCat',
+              title: 'Find a cat',
+            }),
+          },
+          {
+            link: '/operations/findSphynx',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/findSphynx',
+              title: 'Find a sphynx cat',
+            }),
+          },
+        ],
+      },
+      {
+        text: 'fluffy',
+        items: [
+          {
+            link: '/operations/findCat',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/findCat',
+              title: 'Find a cat',
+            }),
+          },
+          {
+            link: '/operations/findFancyRat',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/findFancyRat',
+              title: 'Find a fancy rat',
+            }),
+          },
+        ],
+      },
+      {
+        text: 'bald',
+        items: [
+          {
+            link: '/operations/findSphynx',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/findSphynx',
+              title: 'Find a sphynx cat',
+            }),
+          },
+        ],
+      },
+      {
+        text: 'small',
+        items: [
+          {
+            link: '/operations/findFancyRat',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/findFancyRat',
+              title: 'Find a fancy rat',
+            }),
+          },
+          {
+            link: '/operations/findLizard',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/findLizard',
+              title: 'Find a lizard',
+            }),
+          },
+        ],
+      },
+      {
+        text: 'rat',
+        items: [
+          {
+            link: '/operations/findFancyRat',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/findFancyRat',
+              title: 'Find a fancy rat',
+            }),
+          },
+        ],
+      },
+      {
+        text: 'reptile',
+        items: [
+          {
+            link: '/operations/findLizard',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/findLizard',
+              title: 'Find a lizard',
+            }),
+          },
+        ],
+      },
+      {
+        text: 'lizard',
+        items: [
+          {
+            link: '/operations/findLizard',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/findLizard',
+              title: 'Find a lizard',
+            }),
+          },
+        ],
+      },
+      {
+        text: 'Default',
+        items: [
+          {
+            link: '/operations/accountStats',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/accountStats',
+              title: 'Get user stats',
+            }),
+          },
+          {
+            link: '/operations/checkStatus',
+            text: sidebar.sidebarItemTemplate({
+              method: 'get',
+              path: '/checkStatus',
+              title: 'Check status',
+            }),
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/test/composables/useSidebar.multipleTags.test.ts
+++ b/test/composables/useSidebar.multipleTags.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { useSidebar } from '../../src/composables/useSidebar'
 
 const spec = {


### PR DESCRIPTION
This PR fixes an issue with sidebar rendering when multiple operations have multiple tags, and tags are repeated across operations.

Consider this spec:

```yaml
paths:
  /api/cats:
    get:
      tags:
        - 'mammal'
        - 'cat'
        - 'fluffy'
      summary: 'Find a cat'
      operationId: 'findCat'
      responses:
        200:
          description: 'OK'
  /api/sphynxs:
    get:
      tags:
        - 'mammal'
        - 'cat'
        - 'bald'
      summary: 'Find a sphynx cat'
      operationId: 'findSphynx'
      responses:
        200:
          description: 'OK'
  /api/fancyrats:
    get:
      tags:
        - 'mammal'
        - 'fluffy'
        - 'small'
        - 'rat'
      summary: 'Find a fancy rat'
      operationId: 'findFancyRat'
      responses:
        200:
          description: 'OK'
  /api/lizards:
    get:
      tags:
        - 'small'
        - 'reptile'
        - 'lizard'
      summary: 'Find a lizard'
      operationId: 'findLizard'
      responses:
        200:
          description: 'OK'
  /account/stats:
    get:
      summary: 'Get user stats'
      operationId: 'accountStats'
      responses:
        200:
          description: 'OK'
  /status:
    get:
      summary: 'Check status'
      operationId: 'checkStatus'
      responses:
        200:
          description: 'OK'
```

Note how the `tags` fields are organized: essentially, it is a many-to-many relationship where one operation may have multiple tags, and the same tag may be assigned to multiple operations.

When we opt into the sidebar "Operations grouped by tags" feature, we expect to see each tag that has operations as a group, and each such tag should contain all operations associated with it.

But in the current implementation of the `useSidebar` composable, the rendered sidebar looks like this:

<img width=220px src=https://github.com/user-attachments/assets/a577e109-3d85-492f-a66f-2aee2637cfa7 >

The grouping is broken: some tags/groups are empty (though still displayed), and the logic for which tag/group contains a specific operation is undefined. For example, if we reorder the `tags` array in one of the later operations, we get a completely different sidebar.

This PR fixes the issue and makes the sidebar "Operations grouped by tags" (`useSidebar(...).generateSidebarGroups()`) output consistent—always displaying all tags with operations, and including all relevant operations under each tag, even if they appear multiple times. If the user doesn't want duplicates, they can exclude certain tags using the existing `tags` option or map over the return value of `generateSidebarGroups` and filter as needed.

<img width=220px src=https://github.com/user-attachments/assets/951776b1-b65c-4eb3-9a75-445e531f9ebb >
