### PR TITLE
feat: add `markdown.externalLinksNewTab` option in `useTheme` to make external links open in a new tab

### DIFF
--- a/docs/composables/useTheme.md
+++ b/docs/composables/useTheme.md
@@ -133,6 +133,7 @@ export default {
                         return `/example${href}`
                     },
                 },
+                externalLinksNewTab: true,
             },
         })
     }
@@ -218,6 +219,7 @@ export default {
 
 | Function              | Description                       | Default Value                                                | Allowed Values                                                                                                                                                                    |
 |------------------------|-----------------------------------|------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| 
-| `setMarkdownConfig`    | Sets the markdown configuration.  | `{ operationLink: { linkPrefix: '/operations/' } }`        | `{ operationLink: { linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string } }`            |
-| `getMarkdownConfig`    | Gets the markdown configuration.  | `{ operationLink: { linkPrefix: '/operations/' } }`        | `{ operationLink: { linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string } }` |
+| `setMarkdownConfig`    | Sets the markdown configuration.  | `{ operationLink: { linkPrefix: '/operations/' }, externalLinksNewTab: false }`        | `{ operationLink: { linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string }, externalLinksNewTab: boolean }`            |
+| `getMarkdownConfig`    | Gets the markdown configuration.  | `{ operationLink: { linkPrefix: '/operations/' }, externalLinksNewTab: false }`        | `{ operationLink: { linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string }, externalLinksNewTab: boolean }` |
 | `getOperationLinkConfig` | Gets the operation link configuration. | `{ linkPrefix: '/operations/' }`                    | `{ linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string }`                    |
+| `getExternalLinksNewTab` | Gets whether external links open in new tab. | `false` | `true`, `false` |

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-vue-next": "^0.503.0",
+    "markdown-it-link-attributes": "^4.0.1",
     "reka-ui": "^2.2.0"
   },
   "devDependencies": {
@@ -76,6 +77,7 @@
     "@types/har-format": "^1.2.16",
     "@types/js-yaml": "^4.0.9",
     "@types/markdown-it": "^14.1.2",
+    "@types/markdown-it-link-attributes": "^3.0.5",
     "@types/node": "^22.15.2",
     "@vitejs/plugin-vue": "^5.2.3",
     "allof-merge": "^0.6.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       lucide-vue-next:
         specifier: ^0.503.0
         version: 0.503.0(vue@3.5.13(typescript@5.8.3))
+      markdown-it-link-attributes:
+        specifier: ^4.0.1
+        version: 4.0.1
       reka-ui:
         specifier: ^2.2.0
         version: 2.2.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
@@ -69,6 +72,9 @@ importers:
       '@types/markdown-it':
         specifier: ^14.1.2
         version: 14.1.2
+      '@types/markdown-it-link-attributes':
+        specifier: ^3.0.5
+        version: 3.0.5
       '@types/node':
         specifier: ^22.15.2
         version: 22.15.2
@@ -1275,6 +1281,9 @@ packages:
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it-link-attributes@3.0.5':
+    resolution: {integrity: sha512-VZ2BGN3ywUg7mBD8W6PwR8ChpOxaQSBDbLqPgvNI+uIra3zY2af1eG/3XzWTKjEraTWskMKnZqZd6m1fDF67Bg==}
 
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
@@ -2577,6 +2586,9 @@ packages:
 
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
+
+  markdown-it-link-attributes@4.0.1:
+    resolution: {integrity: sha512-pg5OK0jPLg62H4k7M9mRJLT61gUp9nvG0XveKYHMOOluASo9OEF13WlXrpAp2aj35LbedAy3QOCgQCw0tkLKAQ==}
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
@@ -4594,6 +4606,10 @@ snapshots:
 
   '@types/linkify-it@5.0.0': {}
 
+  '@types/markdown-it-link-attributes@3.0.5':
+    dependencies:
+      '@types/markdown-it': 14.1.2
+
   '@types/markdown-it@14.1.2':
     dependencies:
       '@types/linkify-it': 5.0.0
@@ -5975,6 +5991,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   mark.js@8.11.1: {}
+
+  markdown-it-link-attributes@4.0.1: {}
 
   markdown-it@14.1.0:
     dependencies:

--- a/src/composables/useMarkdown.ts
+++ b/src/composables/useMarkdown.ts
@@ -1,14 +1,33 @@
 import markdownit from 'markdown-it'
+import linkAttributes from 'markdown-it-link-attributes'
 import { operationLink } from '../lib/markdown/operationLink'
 import { useTheme } from './useTheme'
 
 export function useMarkdown() {
-  const operationLinkConfig = useTheme().getOperationLinkConfig()
+  const theme = useTheme()
+  const operationLinkConfig = theme.getOperationLinkConfig()
+  const { externalLinksNewTab } = theme.getMarkdownConfig()
 
   const md = markdownit({
     html: true,
     breaks: true,
-  }).use(operationLink, operationLinkConfig)
+  })
+
+  if (externalLinksNewTab) {
+    md.use(linkAttributes, [
+      {
+        matcher(href: string) {
+          return /^https?:\/\//.test(href)
+        },
+        attrs: {
+          target: '_blank',
+          rel: 'noopener',
+        },
+      },
+    ])
+  }
+
+  md.use(operationLink, operationLinkConfig)
 
   function render(content: string) {
     // Ensure we always return a valid HTML string even for empty/undefined content.

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -150,6 +150,7 @@ export interface OperationLinkConfig {
 
 export interface MarkdownConfig {
   operationLink?: OperationLinkConfig
+  externalLinksNewTab?: boolean
 }
 
 export interface UseThemeConfig {
@@ -358,6 +359,7 @@ const defaultValues = {
     operationLink: {
       linkPrefix: DEFAULT_OPERATIONS_PREFIX,
     },
+    externalLinksNewTab: false,
   },
 }
 
@@ -446,6 +448,7 @@ const themeConfig: UseThemeConfig = {
     operationLink: {
       linkPrefix: defaultValues.markdown.operationLink.linkPrefix,
     },
+    externalLinksNewTab: defaultValues.markdown.externalLinksNewTab,
   },
 }
 
@@ -1009,6 +1012,10 @@ export function useTheme(initialConfig: PartialUseThemeConfig = {}) {
     return themeConfig.markdown as MarkdownConfig
   }
 
+  function getExternalLinksNewTab(): boolean {
+    return themeConfig.markdown?.externalLinksNewTab ?? false
+  }
+
   function setMarkdownConfig(config: Partial<UnwrapNestedRefs<MarkdownConfig>>) {
     const markdown = ensureNestedProperty(themeConfig, 'markdown')
 
@@ -1022,6 +1029,10 @@ export function useTheme(initialConfig: PartialUseThemeConfig = {}) {
       if (config.operationLink.transformHref !== undefined) {
         operationLink.transformHref = config.operationLink.transformHref
       }
+    }
+
+    if (config.externalLinksNewTab !== undefined) {
+      markdown.externalLinksNewTab = config.externalLinksNewTab
     }
   }
 
@@ -1100,6 +1111,7 @@ export function useTheme(initialConfig: PartialUseThemeConfig = {}) {
     setServerConfig,
     getServerAllowCustomServer,
     getMarkdownConfig,
+    getExternalLinksNewTab,
     setMarkdownConfig,
     getOperationLinkConfig,
   }

--- a/test/composables/useMarkdown.test.ts
+++ b/test/composables/useMarkdown.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { useMarkdown } from '../../src/composables/useMarkdown'
+import { useTheme } from '../../src/composables/useTheme'
 
 describe('useMarkdown', () => {
   it('should return a markdown-it instance', () => {
@@ -25,5 +26,13 @@ describe('useMarkdown', () => {
     const { render } = useMarkdown()
     const result = render(undefined)
     expect(result).toBe('')
+  })
+
+  it('adds target="_blank" to external links when configured', () => {
+    const theme = useTheme()
+    theme.setMarkdownConfig({ externalLinksNewTab: true })
+    const { render } = useMarkdown()
+    const result = render('[link](https://example.com)')
+    expect(result).toContain('target="_blank"')
   })
 })

--- a/test/composables/useTheme.test.ts
+++ b/test/composables/useTheme.test.ts
@@ -741,6 +741,7 @@ describe('markdown configuration', () => {
     const result = themeConfig.getMarkdownConfig()
     expect(result.operationLink).toBeDefined()
     expect(result.operationLink?.linkPrefix).toBe('/operations/')
+    expect(result.externalLinksNewTab).toBe(false)
   })
 
   it('sets and gets the markdown config', () => {
@@ -749,15 +750,23 @@ describe('markdown configuration', () => {
         linkPrefix: '/custom-operations/',
         transformHref: href => `/transformed${href}`,
       },
+      externalLinksNewTab: true,
     })
     const result = themeConfig.getMarkdownConfig()
     expect(result.operationLink?.linkPrefix).toBe('/custom-operations/')
     expect(result.operationLink?.transformHref).toBeTypeOf('function')
+    expect(result.externalLinksNewTab).toBe(true)
   })
 
   it('returns the operation link config', () => {
     const result = themeConfig.getOperationLinkConfig()
     expect(result?.linkPrefix).toBe('/operations/')
+  })
+
+  it('returns the externalLinksNewTab value', () => {
+    themeConfig.setMarkdownConfig({ externalLinksNewTab: true })
+    const result = themeConfig.getExternalLinksNewTab()
+    expect(result).toBe(true)
   })
 })
 


### PR DESCRIPTION
This PR introduces a new `externalLinksNewTab` option in the `markdown` configuration of the `useTheme`, which makes links from the parsed markdown open in a new tab when that option is set to `true`.

New dep `markdown-it-link-attributes` added. However, if we prefer not to use additional dependencies (even though it's tiny), we can implement our own override for the markdown-it renderer as described [here](https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer). Let me know and I adjust the PR.