### PR TITLE
fix: make interaction with collapsible sections more predictable

### DIFF
--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -83,7 +83,7 @@ const unionBadge = computed(() => {
       :disabled="!isObjectOrArray"
     >
       <CollapsibleTrigger class="w-full">
-        <div class="flex flex-col text-start space-y-1 group select-text cursor-auto">
+        <div class="flex flex-col text-start space-y-1 group select-text cursor-pointer">
           <div class="flex flex-row items-center gap-2 text-sm">
             <span
               v-if="props.property.name && props.property.name.trim() !== ''"
@@ -174,21 +174,22 @@ const unionBadge = computed(() => {
               props.property.required === true ? $t('Required') : ''
             }}</span>
           </div>
-
-          <OAMarkdown
-            v-if="props.property?.description"
-            :content="props.property.description"
-            class="text-sm"
-            :class="{
-              'pl-2': isObjectOrArray,
-            }"
-          />
-
-          <OASchemaPropertyAttributes v-if="props.property.enum" :property="{ [$t('valid values')]: props.property.enum }" />
-
-          <OASchemaPropertyAttributes v-if="props.property.constraints" :property="props.property.constraints" />
         </div>
       </CollapsibleTrigger>
+
+      <OAMarkdown
+        v-if="props.property?.description"
+        :content="props.property.description"
+        class="text-sm"
+        :class="{
+          'pl-2': isObjectOrArray,
+        }"
+      />
+
+      <OASchemaPropertyAttributes v-if="props.property.enum" :property="{ [$t('valid values')]: props.property.enum }" />
+
+      <OASchemaPropertyAttributes v-if="props.property.constraints" :property="props.property.constraints" />
+
       <CollapsibleContent v-if="isObjectOrArray" class="ml-2 pl-2 border-l border-l-solid">
         <Badge
           v-if="isUnion"


### PR DESCRIPTION
Interaction with collapsible schema sections such as objects was sometimes difficult. For example, certain common tasks like copying text—or, if #260 is merged, clicking on an external link—would expand or collapse the section.

Additionally, it wasn't obvious whether clicking would trigger any action like expansion or collapse, since the cursor doesn't change when it enters the trigger area.

This PR solves both problems.

Behavior before:

https://github.com/user-attachments/assets/735929e0-f09b-4b9a-850e-1d108ae3c892

Behavior after:

https://github.com/user-attachments/assets/27605884-9c3e-42fe-9eda-2b14886295de