### PR TITLE
fix: fix responses tabs overlapping when not enough space

### DIFF
--- a/src/components/Response/OAResponses.vue
+++ b/src/components/Response/OAResponses.vue
@@ -56,7 +56,6 @@ const tabsSelector = computed(() => {
           {{ $t('Responses') }}
         </OAHeading>
         <div
-          class="relative"
           :class="{
             'overflow-x-auto': responsesCodes.length > 1,
           }"


### PR DESCRIPTION
This PR fixes the issue with overlapping elements when an operation has multiple response codes and the current mode is set to "tabs".

Before:

[<video width=300px src=></video>](https://github.com/user-attachments/assets/a10b2bf8-7a86-4abe-a7ef-6326da648f49)

After:

https://github.com/user-attachments/assets/c4e0e197-60f4-4d7d-8968-8ce2465d938d
