### PR TITLE
fix: add missing i18n messages

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -55,5 +55,7 @@
   "Expand all": "Expand all",
   "Collapse": "Collapse",
   "Expand": "Expand",
-  "Download OpenAPI Document": "Download OpenAPI Document"
+  "Download OpenAPI Document": "Download OpenAPI Document",
+  "Any of": "Any of",
+  "valid values": "valid values"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -55,5 +55,7 @@
   "Expand all": "Expandir todo",
   "Collapse": "Colapsar",
   "Expand": "Expandir",
-  "Download OpenAPI Document": "Descargar Documento OpenAPI"
+  "Download OpenAPI Document": "Descargar Documento OpenAPI",
+  "Any of": "Cualquiera de",
+  "valid values": "valores válidos"
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -55,5 +55,7 @@
   "Expand all": "すべて展開",
   "Collapse": "折りたたむ",
   "Expand": "展開",
-  "Download OpenAPI Document": "OpenAPI ドキュメントをダウンロード"
+  "Download OpenAPI Document": "OpenAPI ドキュメントをダウンロード",
+  "Any of": "いずれか",
+  "valid values": "有効な値"
 }

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -55,5 +55,7 @@
   "Expand all": "Expandir tudo",
   "Collapse": "Recolher",
   "Expand": "Expandir",
-  "Download OpenAPI Document": "Baixar Documento OpenAPI"
+  "Download OpenAPI Document": "Baixar Documento OpenAPI",
+  "Any of": "Qualquer um dos",
+  "valid values": "valores válidos"
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -55,5 +55,7 @@
   "Expand all": "全部展开",
   "Collapse": "折叠",
   "Expand": "展开",
-  "Download OpenAPI Document": "下载 OpenAPI 文档"
+  "Download OpenAPI Document": "下载 OpenAPI 文档",
+  "Any of": "任意一个",
+  "valid values": "有效值"
 }


### PR DESCRIPTION
**OASchemaUI.vue** uses the following `t` calls:

* `t('Any of')`
* `t('valid values')`

but neither is present in any locale, including **`en`**.

This PR adds these two missing messages to all locales.
