### PR TITLE
fix: ensure proper circular references detection

### DIFF
--- a/src/lib/parser/dereferenceWithAnnotations.ts
+++ b/src/lib/parser/dereferenceWithAnnotations.ts
@@ -1,7 +1,19 @@
 import type { JSONSchema } from '@trojs/openapi-dereference'
 
+// Symbol used as a non-enumerable marker to preserve the original identity of
+// each schema node. It allows us to detect circular references later even after
+// objects are cloned during dereferencing.
+export const originSymbol = Symbol('origin')
+
+// Cache resolved $refs per root schema to avoid repeatedly walking the same JSON pointer path
 const refCache = new Map<JSONSchema, Map<string, unknown>>()
 
+/**
+ * Resolve a JSON Pointer against the provided schema.
+ * The implementation mirrors the one from @trojs/openapi-dereference but is
+ * inlined here so we can tweak dereferencing behaviour.
+ * Results are cached per schema for performance.
+ */
 export function resolveRefSync(schema: JSONSchema, ref: string): unknown {
   if (!refCache.has(schema)) {
     refCache.set(schema, new Map())
@@ -13,9 +25,13 @@ export function resolveRefSync(schema: JSONSchema, ref: string): unknown {
     return schemaCache.get(ref)
   }
 
+  // The ref is a JSON pointer, so walk through the path segments to find the
+  // referenced node in the schema. The leading "#" is removed by splitting.
   const path = ref.split('/').slice(1)
 
   let current: any = schema
+  // Walk segment by segment until we either reach the target or hit a dead end
+  // (e.g. the pointer references a non-object).
   for (const segment of path) {
     if (!current || typeof current !== 'object') {
       current = null
@@ -28,7 +44,8 @@ export function resolveRefSync(schema: JSONSchema, ref: string): unknown {
   return current
 }
 
-// Lightweight deep clone based on klona
+// Lightweight deep clone based on https://github.com/lukeed/klona, License - MIT;
+// implementation from the @trojs/openapi-dereference https://trojs.org/, License - MIT.
 export function klona(val: any): any {
   if (Array.isArray(val)) {
     const out = Array.from({ length: val.length })
@@ -59,6 +76,35 @@ export function klona(val: any): any {
   return val
 }
 
+// Recursively walk the cloned schema and attach the origin symbol to each node.
+// The function uses a WeakSet to avoid infinite loops in case of cycles.
+function markOrigins(obj: any, visited = new WeakSet()) {
+  if (obj && typeof obj === 'object' && !visited.has(obj)) {
+    visited.add(obj)
+
+    Object.defineProperty(obj, originSymbol, { value: obj, enumerable: false })
+
+    const values = Array.isArray(obj) ? obj : Object.values(obj)
+
+    for (const value of values) {
+      markOrigins(value, visited)
+    }
+  }
+}
+
+// Clone an object or array while retaining the origin symbol from the source
+function cloneWithOrigins(src: any): any {
+  const target = Array.isArray(src) ? [...src] : { ...src }
+
+  Object.defineProperty(target, originSymbol, {
+    value: src[originSymbol] || src,
+    enumerable: false,
+  })
+
+  return target
+}
+
+// Keys that represent annotations allowed next to a $ref according to the JSON Schema specification
 const annotationKeys = new Set([
   'title',
   'description',
@@ -71,8 +117,13 @@ const annotationKeys = new Set([
   'example',
 ])
 
+// Cache for fully dereferenced schemas so repeated calls are cheap
 const cache = new Map<JSONSchema, JSONSchema>()
 
+/**
+ * Dereference the given schema while merging JSON-schema annotations that appear next to a $ref node.
+ * Circular references are preserved via the originSymbol so downstream code can still detect them.
+ */
 export function dereferenceWithAnnotationsSync(schema: JSONSchema): JSONSchema {
   if (cache.has(schema)) {
     return cache.get(schema) as JSONSchema
@@ -80,26 +131,35 @@ export function dereferenceWithAnnotationsSync(schema: JSONSchema): JSONSchema {
 
   const visitedNodes = new Set<any>()
   const cloned = klona(schema)
+  markOrigins(cloned)
 
   const resolve = (current: any): any => {
     if (typeof current === 'object' && current !== null) {
+      // Don't process the same object twice to prevent infinite recursion on circular structures
       if (visitedNodes.has(current)) {
         return current
       }
       visitedNodes.add(current)
 
       if (Array.isArray(current)) {
+        // Recurse into array items
         for (let index = 0; index < current.length; index++) {
           current[index] = resolve(current[index])
         }
       } else {
         if ('$ref' in current && typeof current.$ref === 'string') {
+          // Follow $ref pointers until we reach a concrete schema object
           let ref: any = current
           do {
             ref = resolveRefSync(cloned, ref.$ref)
           } while (ref?.$ref)
-          ref = klona(ref)
+
+          // Clone the referenced object so that adding annotations doesn't mutate the cache
+          // and keep track of where it originated from
+          ref = cloneWithOrigins(ref)
           ref = resolve(ref)
+
+          // Merge annotations that were defined next to the $ref
           for (const key in current) {
             if (key !== '$ref' && annotationKeys.has(key)) {
               ref[key] = current[key]
@@ -107,6 +167,8 @@ export function dereferenceWithAnnotationsSync(schema: JSONSchema): JSONSchema {
           }
           return ref
         }
+
+        // Recurse into object properties
         for (const key in current) {
           current[key] = resolve(current[key])
         }
@@ -115,6 +177,7 @@ export function dereferenceWithAnnotationsSync(schema: JSONSchema): JSONSchema {
     return current
   }
 
+  // Start resolution from the cloned root object
   const result = resolve(cloned)
   cache.set(schema, result)
   return result

--- a/src/lib/parser/resolveCircularRef.ts
+++ b/src/lib/parser/resolveCircularRef.ts
@@ -51,18 +51,20 @@ function traverseNode(node: SchemaNode): void {
 
 function detectCircularReference(
   ancestor: SchemaNode | null,
-  value: any
+  value: any,
 ): string | null {
-  const target =
-    value && (value as any)[originSymbol] ? (value as any)[originSymbol] : value
-  
+  const target
+    = value && (value as any)[originSymbol]
+      ? (value as any)[originSymbol]
+      : value
+
   while (ancestor) {
     const ancestorValue = ancestor.value
-    const ancestorTarget =
-      ancestorValue && (ancestorValue as any)[originSymbol]
+    const ancestorTarget
+      = ancestorValue && (ancestorValue as any)[originSymbol]
         ? (ancestorValue as any)[originSymbol]
         : ancestorValue
-        
+
     if (ancestorTarget === target) {
       return buildReferencePath(ancestor)
     }

--- a/src/lib/parser/resolveCircularRef.ts
+++ b/src/lib/parser/resolveCircularRef.ts
@@ -1,4 +1,5 @@
 import type { OpenAPI } from '@scalar/openapi-types'
+import { originSymbol } from './dereferenceWithAnnotations'
 
 interface SchemaNode {
   key: string
@@ -48,13 +49,26 @@ function traverseNode(node: SchemaNode): void {
   }
 }
 
-function detectCircularReference(ancestor: SchemaNode | null, value: any): string | null {
+function detectCircularReference(
+  ancestor: SchemaNode | null,
+  value: any
+): string | null {
+  const target =
+    value && (value as any)[originSymbol] ? (value as any)[originSymbol] : value
+  
   while (ancestor) {
-    if (ancestor.value === value) {
+    const ancestorValue = ancestor.value
+    const ancestorTarget =
+      ancestorValue && (ancestorValue as any)[originSymbol]
+        ? (ancestorValue as any)[originSymbol]
+        : ancestorValue
+        
+    if (ancestorTarget === target) {
       return buildReferencePath(ancestor)
     }
     ancestor = ancestor.parent
   }
+
   return null
 }
 

--- a/test/lib/processOpenAPI/parseOpenapi.circularRef.test.ts
+++ b/test/lib/processOpenAPI/parseOpenapi.circularRef.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { getSchemaUi } from '../../../src/lib/parser/getSchemaUi'
+import { specWithCircularRef } from '../../testsConstants'
+import { parseOpenapi } from '../../../src/lib/parser/parseOpenapi'
+
+describe('parseOpenapi circular references', () => {
+  it('marks circular references in schema UI', () => {
+    const openapi = parseOpenapi().parseSync({ spec: specWithCircularRef })
+    const schema = getSchemaUi((openapi as any).components.schemas.Parent)
+
+    const child = (schema as any).properties?.find((p: any) => p.name === 'child')
+    const parentProp = child?.properties?.find((p: any) => p.name === 'parent')
+
+    expect(parentProp?.meta?.isCircularReference).toBe(true)
+  })
+})
+

--- a/test/lib/processOpenAPI/parseOpenapi.circularRef.test.ts
+++ b/test/lib/processOpenAPI/parseOpenapi.circularRef.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { getSchemaUi } from '../../../src/lib/parser/getSchemaUi'
-import { specWithCircularRef } from '../../testsConstants'
 import { parseOpenapi } from '../../../src/lib/parser/parseOpenapi'
+import { specWithCircularRef } from '../../testsConstants'
 
 describe('parseOpenapi circular references', () => {
   it('marks circular references in schema UI', () => {


### PR DESCRIPTION
Well, so after #256 followed by #268, I realized that the initial implementation of a custom dereferencer introduced in #256 was incorrect, as @enzonotario noticed - it broke circular reference handling, leading to the schema type being displayed as `string` in the UI instead of showing the proper object shape with a `Circular Reference` badge where the recursion starts.

### What exactly happened, and why this PR instead of #268:

In #256, the existing `dereferenceSync` from **@trojs/openapi-dereference** was replaced with a custom dereference implementation (`dereferenceWithAnnotationsSync`), which was based on the @trojs version but enhanced to handle cases where schema annotations ("default", "description", etc.) were present on the same level as `$ref`. To add annotations to the referenced object, we - unlike `dereferenceSync` from @trojs - cannot reuse the same object; we must clone it (otherwise, we would change the displayed annotations in every place where that ref is used).

But `resolveCircularRef` relied on object identity to detect circular references - that's essential for it. And since our new `dereferenceWithAnnotationsSync` always cloned resolved objects, `resolveCircularRef` never observed the same object instance and failed to mark a circular reference. Instead, the first repeated reference encountered is usually the shared properties object, producing a path like `/root/properties` rather than `/root`. As a result, the UI falls back to rendering the child schema as just `"string"`.

#268 attempts to address this by shallow-copying the referenced object and recursively resolving its fields, but the returned object is still a new object, so reference identity remains broken and the circular reference detector still fails.

### The current PR
...addresses this in a different way: since we need to provide something for `resolveCircularRef` that allows it to check the identity of objects in a tree, it attaches an `originSymbol` to each node during dereferencing, so that **cloned** references retain identity information.

Also, it:

* Updates circular reference detection to compare these origin markers, enabling correct identification of cycles in dereferenced schemas
* Adds a regression test ensuring schemas with circular references are recognized properly in the schema UI
* Adds comments for unobvious parts to `dereferenceWithAnnotationsSync.ts`

### Limitations:

If a `$ref` points to an object in a way that creates circular references, we still won't see any annotations from that `$ref` level (previously we also didn't see any annotations from the referenced object in such cases - so this is not a regression).