### PR TITLE
feat: add `markdown.config` option to `useTheme()` to allow `markdown‑it` customization

### DIFF
--- a/docs/composables/useTheme.md
+++ b/docs/composables/useTheme.md
@@ -136,6 +136,7 @@ export default {
                     },
                 },
                 externalLinksNewTab: true,
+                config: md => md,
             },
         })
     }
@@ -221,7 +222,28 @@ export default {
 
 | Function              | Description                       | Default Value                                                | Allowed Values                                                                                                                                                                    |
 |------------------------|-----------------------------------|------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| 
-| `setMarkdownConfig`    | Sets the markdown configuration.  | `{ operationLink: { linkPrefix: '/operations/' }, externalLinksNewTab: false }`        | `{ operationLink: { linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string }, externalLinksNewTab: boolean }`            |
-| `getMarkdownConfig`    | Gets the markdown configuration.  | `{ operationLink: { linkPrefix: '/operations/' }, externalLinksNewTab: false }`        | `{ operationLink: { linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string }, externalLinksNewTab: boolean }` |
+| `setMarkdownConfig`    | Sets the markdown configuration.  | `{ operationLink: { linkPrefix: '/operations/' }, externalLinksNewTab: false }`        | `{ operationLink: { linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string } \| false, externalLinksNewTab: boolean, config: (md) => MarkdownIt }`            |
+| `getMarkdownConfig`    | Gets the markdown configuration.  | `{ operationLink: { linkPrefix: '/operations/' }, externalLinksNewTab: false }`        | `{ operationLink: { linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string } \| false, externalLinksNewTab: boolean, config: (md) => MarkdownIt }` |
 | `getOperationLinkConfig` | Gets the operation link configuration. | `{ linkPrefix: '/operations/' }`                    | `{ linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string }`                    |
 | `getExternalLinksNewTab` | Gets whether external links open in new tab. | `false` | `true`, `false` |
+
+
+You can also customize the markdown renderer with the `config` callback:
+
+```ts
+useTheme({
+  markdown: {
+    config: md => {
+      // add custom markdown-it plugins
+      md.use(myPlugin, myParams)
+      return;
+
+      // or return your own instance
+      const myMd = (/* ... */)
+      return myMd
+    },
+  },
+})
+```
+
+`md` is an instance of [markdown-it](https://github.com/markdown-it/markdown-it).

--- a/docs/customizations/operation-links.md
+++ b/docs/customizations/operation-links.md
@@ -97,4 +97,23 @@ The plugin will transform it into:
 
 ### Usage in Markdown
 
-WIP.
+You can write links using the `/operations/` prefix directly in Markdown. The plugin
+converts them into `OAOperationLink` components with the correct HTTP method badge.
+
+```markdown
+The [Get Artists](/operations/getAllArtists) operation retrieves all artists.
+```
+
+### Disabling the plugin
+
+If you prefer to handle these links yourself, disable the plugin via `useTheme`:
+
+```ts
+import { useTheme } from 'vitepress-openapi/client'
+
+useTheme({
+  markdown: {
+    operationLink: false,
+  },
+})
+```

--- a/src/composables/useMarkdown.ts
+++ b/src/composables/useMarkdown.ts
@@ -6,9 +6,9 @@ import { useTheme } from './useTheme'
 export function useMarkdown() {
   const theme = useTheme()
   const operationLinkConfig = theme.getOperationLinkConfig()
-  const { externalLinksNewTab } = theme.getMarkdownConfig()
+  const { externalLinksNewTab, config } = theme.getMarkdownConfig()
 
-  const md = markdownit({
+  let md = markdownit({
     html: true,
     breaks: true,
   })
@@ -27,7 +27,14 @@ export function useMarkdown() {
     ])
   }
 
-  md.use(operationLink, operationLinkConfig)
+  if (operationLinkConfig !== false) {
+    md.use(operationLink, operationLinkConfig)
+  }
+
+  if (config) {
+    // user can mutate existing md to add plugins or return completely different instance
+    md = config(md) || md
+  }
 
   function render(content: string) {
     // Ensure we always return a valid HTML string even for empty/undefined content.

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -1,3 +1,4 @@
+import type MarkdownIt from 'markdown-it'
 import type { Ref, UnwrapNestedRefs } from 'vue'
 import type { OARequest } from '../lib/codeSamples/request'
 import type { OperationSlot, ParsedOperation } from '../types'
@@ -9,11 +10,11 @@ import { generateCodeSample } from '../lib/codeSamples/generateCodeSample'
 import { deepUnref } from '../lib/deepUnref'
 import { locales } from '../locales'
 
-function ensureNestedProperty<T, K extends keyof T>(obj: T, key: K): NonNullable<T[K]> {
+function ensureNestedProperty<T, K extends keyof T>(obj: T, key: K): Exclude<NonNullable<T[K]>, false> {
   if (!obj[key]) {
     obj[key] = {} as T[K]
   }
-  return obj[key] as NonNullable<T[K]>
+  return obj[key] as Exclude<NonNullable<T[K]>, false>
 }
 
 function ensureRefProperty<T, K extends keyof T, V>(obj: T, key: K, propName: string, value: V): Ref<V> {
@@ -149,8 +150,9 @@ export interface OperationLinkConfig {
 }
 
 export interface MarkdownConfig {
-  operationLink?: OperationLinkConfig
+  operationLink?: OperationLinkConfig | false
   externalLinksNewTab?: boolean
+  config?: (md: MarkdownIt) => MarkdownIt | void
 }
 
 export interface UseThemeConfig {
@@ -360,6 +362,7 @@ const defaultValues = {
       linkPrefix: DEFAULT_OPERATIONS_PREFIX,
     },
     externalLinksNewTab: false,
+    config: undefined,
   },
 }
 
@@ -449,6 +452,7 @@ const themeConfig: UseThemeConfig = {
       linkPrefix: defaultValues.markdown.operationLink.linkPrefix,
     },
     externalLinksNewTab: defaultValues.markdown.externalLinksNewTab,
+    config: defaultValues.markdown.config,
   },
 }
 
@@ -1019,24 +1023,32 @@ export function useTheme(initialConfig: PartialUseThemeConfig = {}) {
   function setMarkdownConfig(config: Partial<UnwrapNestedRefs<MarkdownConfig>>) {
     const markdown = ensureNestedProperty(themeConfig, 'markdown')
 
-    if (config.operationLink) {
-      const operationLink = ensureNestedProperty(markdown, 'operationLink')
+    if (config.operationLink !== undefined) {
+      if (config.operationLink === false) {
+        markdown.operationLink = false
+      } else {
+        const operationLink = ensureNestedProperty(markdown, 'operationLink')
 
-      if (config.operationLink.linkPrefix !== undefined) {
-        operationLink.linkPrefix = config.operationLink.linkPrefix
-      }
+        if (config.operationLink.linkPrefix !== undefined) {
+          operationLink.linkPrefix = config.operationLink.linkPrefix
+        }
 
-      if (config.operationLink.transformHref !== undefined) {
-        operationLink.transformHref = config.operationLink.transformHref
+        if (config.operationLink.transformHref !== undefined) {
+          operationLink.transformHref = config.operationLink.transformHref
+        }
       }
     }
 
     if (config.externalLinksNewTab !== undefined) {
       markdown.externalLinksNewTab = config.externalLinksNewTab
     }
+
+    if (config.config !== undefined) {
+      markdown.config = config.config
+    }
   }
 
-  function getOperationLinkConfig(): OperationLinkConfig | undefined {
+  function getOperationLinkConfig(): OperationLinkConfig | false | undefined {
     return themeConfig.markdown?.operationLink
   }
 

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -152,7 +152,7 @@ export interface OperationLinkConfig {
 export interface MarkdownConfig {
   operationLink?: OperationLinkConfig | false
   externalLinksNewTab?: boolean
-  config?: (md: MarkdownIt) => MarkdownIt | void
+  config?: (md: MarkdownIt) => MarkdownIt | undefined
 }
 
 export interface UseThemeConfig {

--- a/test/composables/useMarkdown.test.ts
+++ b/test/composables/useMarkdown.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
-import MarkdownIt from 'markdown-it'
+import type MarkdownIt from 'markdown-it'
 import { useMarkdown } from '../../src/composables/useMarkdown'
-import { useTheme } from '../../src/composables/useTheme'
 import { useOpenapi } from '../../src/composables/useOpenapi'
+import { useTheme } from '../../src/composables/useTheme'
 import { spec } from '../testsConstants'
 
 describe('useMarkdown', () => {

--- a/test/composables/useMarkdown.test.ts
+++ b/test/composables/useMarkdown.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import MarkdownIt from 'markdown-it'
 import { useMarkdown } from '../../src/composables/useMarkdown'
 import { useTheme } from '../../src/composables/useTheme'
+import { useOpenapi } from '../../src/composables/useOpenapi'
+import { spec } from '../testsConstants'
 
 describe('useMarkdown', () => {
   it('should return a markdown-it instance', () => {
@@ -34,5 +37,25 @@ describe('useMarkdown', () => {
     const { render } = useMarkdown()
     const result = render('[link](https://example.com)')
     expect(result).toContain('target="_blank"')
+  })
+
+  it('does not transform operation links when disabled', () => {
+    const theme = useTheme()
+    theme.reset()
+    theme.setMarkdownConfig({ operationLink: false })
+    useOpenapi({ spec })
+    const { render } = useMarkdown()
+    const result = render('[Get Users](/operations/getUsers)')
+    expect(result).toContain('<a href="/operations/getUsers">Get Users</a>')
+    expect(result).not.toContain('OAOperationLink')
+  })
+
+  it('calls config function from markdown config', () => {
+    const theme = useTheme()
+    theme.reset()
+    const configFn = vi.fn((md: MarkdownIt) => md)
+    theme.setMarkdownConfig({ config: configFn })
+    useMarkdown()
+    expect(configFn).toHaveBeenCalled()
   })
 })

--- a/test/composables/useTheme.test.ts
+++ b/test/composables/useTheme.test.ts
@@ -768,6 +768,19 @@ describe('markdown configuration', () => {
     const result = themeConfig.getExternalLinksNewTab()
     expect(result).toBe(true)
   })
+
+  it('allows disabling operation link processing', () => {
+    themeConfig.setMarkdownConfig({ operationLink: false })
+    const result = themeConfig.getOperationLinkConfig()
+    expect(result).toBe(false)
+  })
+
+  it('stores the markdown config callback', () => {
+    const configFn = () => {}
+    themeConfig.setMarkdownConfig({ config: configFn })
+    const result = themeConfig.getMarkdownConfig()
+    expect(result.config).toBe(configFn)
+  })
 })
 
 describe('codeSamples configuration', () => {


### PR DESCRIPTION
As a follow-up to [this conversation](https://github.com/enzonotario/vitepress-openapi/pull/260#issuecomment-3066121489), this PR adds a new option `markdown.config` to `useTheme()`, which accepts a callback with a `markdown-it` instance as an argument. This allows users to customize Markdown rendering across the specification and its schemas in the UI, by applying their own plugins or replacing the `markdown-it` instance with their own if they prefer.

**Usage example and use-case**

Let's say your spec description fields contain something like JSDoc-style links (a real case if you generate schemas [from TypeScript](https://github.com/vega/ts-json-schema-generator)!). You want to process them as if they were regular Markdown links.

Now you can do, for example:

```ts
useTheme({
  markdown: {
    config: (md) => {
      md.use(jsDocLinks); // adding plugin
    },
  },
});
```

or

```ts
import MarkdownIt from 'markdown-it';

const customMd: MarkdownIt = (/*...*/) // custom renderer, plugins, rules, etc

useTheme({
  markdown: {
    config: () => {
      return customMd; // the returned instance will be used
    },
  },
});
```

Wo-a-la! Markdown is under your full control:

**Schema that requires custom processing of descriptions:**

```json
"schema": {
  "description":
    "This link comes from JSDoc: {@link https://github.com/vega/ts-json-schema-generator ts-json-schema-generator}, because schemas for this spec were generated with that tool.\n\n@see https://github.com/vega/ts-json-schema-generator"
}
```

**UI:**

Before (without plugins):

<img width="500" height="283" alt="image" src="https://github.com/user-attachments/assets/5ab7c2ab-d0f6-4c10-93f9-759d3bbbf0a6" />

After (now possible):

<img width="500" height="235" alt="image" src="https://github.com/user-attachments/assets/17e1ed50-230a-4985-8758-cdf3ee6bf7d2" />

*(just an example)*


* Also, this PR adds support for disabling the `operationLink` plugin:

```ts
import { useTheme } from 'vitepress-openapi/client'

useTheme({
  markdown: {
    operationLink: false,
  },
})
```

* And adds new paragraphs with a description of these features to the docs.
