### PR TITLE
fix: Render "Responses" descriptions with OAMarkdown component

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -56,7 +56,7 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "Success Response\n\nThe request was successful and returns a list of artists.\n\nResponse Format\n\nThe response includes:\n- A `data` array containing artist objects\n- Pagination information\n\n> **Note:** You can use the pagination parameters to navigate through large result sets.",
             "content": {
               "application/json": {
                 "schema": {
@@ -127,7 +127,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "Artist Created Successfully\n\nThe artist has been successfully added to our database.\n\nResponse Details\n\nThe response includes the complete artist object with:\n- A newly assigned unique `id`\n- All the information you provided in the request\n\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -157,7 +157,7 @@
             }
           },
           "400": {
-            "description": "Bad Request",
+            "description": "Bad Request\n\nThe server could not process your request due to invalid input.\n\nCommon Causes\n\n- Missing required fields\n- Invalid data format\n- Validation errors\n\n> **Tip:** Check the error message in the response for specific details about what went wrong.",
             "content": {
               "application/json": {
                 "schema": {
@@ -167,7 +167,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Forbidden\n\nYou don't have permission to create this resource.\n\nPossible Reasons\n\n- Your API key doesn't have write permissions\n- You've reached your quota limit\n- The resource is protected",
             "content": {
               "application/json": {
                 "schema": {
@@ -197,7 +197,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Artist Found",
+            "description": "Artist Found\n\nThe requested artist was found and returned successfully.\n\nResponse Format\n\nThe response includes the complete artist object with all available details:\n\n- `id`: Unique identifier for the artist\n- `name`: Full name of the artist\n- `description`: Biographical information\n- `image`: URL to the artist's photo\n- `band`: Primary band association",
             "content": {
               "application/json": {
                 "schema": {
@@ -207,7 +207,7 @@
             }
           },
           "404": {
-            "description": "Artist Not Found",
+            "description": "Artist Not Found\n\nThe requested artist could not be found in our database.\n\nPossible Reasons\n\n- The artist ID doesn't exist\n- The artist has been removed\n- You've entered an incorrect ID\n\n> **Tip:** Double-check the artist ID and try again. You can get a list of all available artists using the [](/operations/getAllArtists) endpoint.",
             "content": {
               "application/json": {
                 "schema": {
@@ -242,7 +242,7 @@
         },
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "Artist Updated Successfully\n\nThe artist information has been successfully updated in our database.\n\nResponse Details\n\nThe response includes the complete updated artist object with all the changes you made.\n\n> **Note:** All fields are returned in the response, even if you only updated some of them.",
             "content": {
               "application/json": {
                 "schema": {
@@ -252,7 +252,7 @@
             }
           },
           "400": {
-            "description": "Bad Request",
+            "description": "Bad Request\n\nThe server could not process your update request due to invalid input.\n\nCommon Causes\n\n- Missing required fields\n- Invalid data format\n- Validation errors\n\n> **Tip:** Check the error message in the response for specific details about what went wrong.",
             "content": {
               "application/json": {
                 "schema": {
@@ -262,7 +262,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Forbidden\n\nYou don't have permission to update this artist.\n\nPossible Reasons\n\n- Your API key doesn't have write permissions\n- You're trying to update a protected artist record\n- You've reached your quota limit",
             "content": {
               "application/json": {
                 "schema": {
@@ -288,7 +288,7 @@
         ],
         "responses": {
           "400": {
-            "description": "Bad Request",
+            "description": "Bad Request - Deprecated Endpoint",
             "content": {
               "application/json": {
                 "schema": {
@@ -298,7 +298,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Forbidden - Deprecated Endpoint",
             "content": {
               "application/json": {
                 "schema": {
@@ -334,7 +334,7 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "Albums Found\n\nThe request was successful and returns a list of albums for the specified artist.\n\nResponse Format\n\nThe response includes:\n- A `data` array containing album objects\n- Pagination information for navigating through large collections\n\n> **Note:** If the artist has no albums, the data array will be empty but the request will still return a 200 status code.",
             "content": {
               "application/json": {
                 "schema": {
@@ -384,7 +384,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "Album Created Successfully\n\nThe album has been successfully added to the artist's discography.\n\nResponse Details\n\nThe response includes the complete album object with:\n- A newly assigned unique `id`\n- All the information you provided in the request\n- The association with the artist\n\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -394,7 +394,7 @@
             }
           },
           "400": {
-            "description": "Bad Request",
+            "description": "Bad Request\n\nThe server could not process your request due to invalid album data.\n\nCommon Causes\n\n- Missing required fields (title, year)\n- Invalid year format (must be a number)\n- Year out of valid range\n\n> **Tip:** Make sure the album year is accurate and in the correct format.",
             "content": {
               "application/json": {
                 "schema": {
@@ -404,7 +404,7 @@
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Forbidden\n\nYou don't have permission to add albums to this artist.\n\nPossible Reasons\n\n- Your API key doesn't have write permissions\n- The artist's discography is locked or protected\n- You've reached your quota for album additions",
             "content": {
               "application/json": {
                 "schema": {
@@ -454,7 +454,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "User Created Successfully\n\nYour account has been created and you can now access the Argentine Rock Legends API.\n\nResponse Details\n\nThe response includes your user information (excluding the password) and your API key for authentication.\n\n> **Important:** Save your API key securely as it will be needed for authenticated requests.",
             "content": {
               "application/json": {
                 "schema": {
@@ -464,7 +464,7 @@
             }
           },
           "400": {
-            "description": "Bad Request",
+            "description": "Registration Failed\n\nThe server could not process your registration request.\n\nCommon Causes\n\n- Email address already in use\n- Missing required fields\n- Password doesn't meet security requirements\n- Invalid email format\n\n> **Tip:** Make sure your email is valid and your password is at least 8 characters long.",
             "content": {
               "application/json": {
                 "schema": {
@@ -537,7 +537,7 @@
     },
     "responses": {
       "BadRequest": {
-        "description": "Bad Request",
+        "description": "Bad Request\n\nThe server could not process your request due to invalid input.\n\nCommon Causes\n\n- Missing required fields\n- Invalid data format\n- Validation errors\n\n> **Tip:** Check the error message in the response for specific details about what went wrong.",
         "content": {
           "application/json": {
             "schema": {
@@ -547,7 +547,7 @@
         }
       },
       "Forbidden": {
-        "description": "Forbidden",
+        "description": "Forbidden\n\nYou don't have permission to access this resource.\n\nPossible Reasons\n\n- Your API key doesn't have the required permissions\n- You've reached your quota limit\n- The resource is protected\n\n> **Note:** If you believe you should have access, please contact support.",
         "content": {
           "application/json": {
             "schema": {
@@ -557,7 +557,7 @@
         }
       },
       "NotFound": {
-        "description": "NotFound",
+        "description": "Resource Not Found\n\nThe requested resource could not be found.\n\nPossible Reasons\n\n- The ID doesn't exist\n- The resource has been removed\n- You've entered an incorrect path\n\n> **Tip:** Double-check the ID and try again.",
         "content": {
           "application/json": {
             "schema": {

--- a/src/components/Response/OAResponse.vue
+++ b/src/components/Response/OAResponse.vue
@@ -38,7 +38,11 @@ const { t } = useI18n()
 
 <template>
   <div class="flex flex-col space-y-4">
-    <OAMarkdown :content="props.response.description" class="text-lg" />
+    <OAMarkdown
+      v-if="props.response.description"
+      :content="props.response.description"
+      class="text-lg"
+    />
 
     <div
       v-if="props.response?.content && contentTypes.length"

--- a/src/components/Response/OAResponse.vue
+++ b/src/components/Response/OAResponse.vue
@@ -41,7 +41,6 @@ const { t } = useI18n()
     <OAMarkdown
       v-if="props.response.description"
       :content="props.response.description"
-      class="text-lg"
     />
 
     <div

--- a/src/components/Response/OAResponse.vue
+++ b/src/components/Response/OAResponse.vue
@@ -3,6 +3,7 @@ import { useI18n } from '@byjohann/vue-i18n'
 import { computed, defineProps, ref } from 'vue'
 import { useTheme } from '../../composables/useTheme'
 import OAContentTypeSelect from '../Common/OAContentTypeSelect.vue'
+import OAMarkdown from '../Common/OAMarkdown.vue'
 import OASchemaTabs from '../Schema/OASchemaTabs.vue'
 import { Label } from '../ui/label'
 
@@ -37,7 +38,7 @@ const { t } = useI18n()
 
 <template>
   <div class="flex flex-col space-y-4">
-    <span class="text-lg">{{ props.response.description }}</span>
+    <OAMarkdown :content="props.response.description" class="text-lg" />
 
     <div
       v-if="props.response?.content && contentTypes.length"

--- a/test/lib/processOpenAPI/__snapshots__/processOpenAPI.test.ts.snap
+++ b/test/lib/processOpenAPI/__snapshots__/processOpenAPI.test.ts.snap
@@ -86,7 +86,17 @@ exports[`processOpenAPI > processes the OpenAPI spec 1`] = `
             },
           },
         },
-        "description": "Bad Request",
+        "description": "Bad Request
+
+The server could not process your request due to invalid input.
+
+Common Causes
+
+- Missing required fields
+- Invalid data format
+- Validation errors
+
+> **Tip:** Check the error message in the response for specific details about what went wrong.",
       },
       "Forbidden": {
         "content": {
@@ -124,7 +134,17 @@ exports[`processOpenAPI > processes the OpenAPI spec 1`] = `
             },
           },
         },
-        "description": "Forbidden",
+        "description": "Forbidden
+
+You don't have permission to access this resource.
+
+Possible Reasons
+
+- Your API key doesn't have the required permissions
+- You've reached your quota limit
+- The resource is protected
+
+> **Note:** If you believe you should have access, please contact support.",
       },
       "NotFound": {
         "content": {
@@ -162,7 +182,17 @@ exports[`processOpenAPI > processes the OpenAPI spec 1`] = `
             },
           },
         },
-        "description": "NotFound",
+        "description": "Resource Not Found
+
+The requested resource could not be found.
+
+Possible Reasons
+
+- The ID doesn't exist
+- The resource has been removed
+- You've entered an incorrect path
+
+> **Tip:** Double-check the ID and try again.",
       },
     },
     "schemas": {
@@ -785,7 +815,17 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "OK",
+            "description": "Success Response
+
+The request was successful and returns a list of artists.
+
+Response Format
+
+The response includes:
+- A \`data\` array containing artist objects
+- Pagination information
+
+> **Note:** You can use the pagination parameters to navigate through large result sets.",
           },
         },
         "security": [
@@ -1195,7 +1235,17 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "Created",
+            "description": "Artist Created Successfully
+
+The artist has been successfully added to our database.
+
+Response Details
+
+The response includes the complete artist object with:
+- A newly assigned unique \`id\`
+- All the information you provided in the request
+
+",
           },
           "400": {
             "content": {
@@ -1301,7 +1351,17 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "Bad Request",
+            "description": "Bad Request
+
+The server could not process your request due to invalid input.
+
+Common Causes
+
+- Missing required fields
+- Invalid data format
+- Validation errors
+
+> **Tip:** Check the error message in the response for specific details about what went wrong.",
           },
           "403": {
             "content": {
@@ -1407,7 +1467,15 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "Forbidden",
+            "description": "Forbidden
+
+You don't have permission to create this resource.
+
+Possible Reasons
+
+- Your API key doesn't have write permissions
+- You've reached your quota limit
+- The resource is protected",
           },
         },
         "securityUi": [
@@ -1609,7 +1677,7 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "Bad Request",
+            "description": "Bad Request - Deprecated Endpoint",
           },
           "403": {
             "content": {
@@ -1715,7 +1783,7 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "Forbidden",
+            "description": "Forbidden - Deprecated Endpoint",
           },
         },
         "securityUi": [
@@ -1933,7 +2001,19 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "Artist Found",
+            "description": "Artist Found
+
+The requested artist was found and returned successfully.
+
+Response Format
+
+The response includes the complete artist object with all available details:
+
+- \`id\`: Unique identifier for the artist
+- \`name\`: Full name of the artist
+- \`description\`: Biographical information
+- \`image\`: URL to the artist's photo
+- \`band\`: Primary band association",
           },
           "404": {
             "content": {
@@ -2039,7 +2119,17 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "Artist Not Found",
+            "description": "Artist Not Found
+
+The requested artist could not be found in our database.
+
+Possible Reasons
+
+- The artist ID doesn't exist
+- The artist has been removed
+- You've entered an incorrect ID
+
+> **Tip:** Double-check the artist ID and try again. You can get a list of all available artists using the [](/operations/getAllArtists) endpoint.",
           },
         },
         "security": [
@@ -2420,7 +2510,15 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "OK",
+            "description": "Artist Updated Successfully
+
+The artist information has been successfully updated in our database.
+
+Response Details
+
+The response includes the complete updated artist object with all the changes you made.
+
+> **Note:** All fields are returned in the response, even if you only updated some of them.",
           },
           "400": {
             "content": {
@@ -2526,7 +2624,17 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "Bad Request",
+            "description": "Bad Request
+
+The server could not process your update request due to invalid input.
+
+Common Causes
+
+- Missing required fields
+- Invalid data format
+- Validation errors
+
+> **Tip:** Check the error message in the response for specific details about what went wrong.",
           },
           "403": {
             "content": {
@@ -2632,7 +2740,15 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "Forbidden",
+            "description": "Forbidden
+
+You don't have permission to update this artist.
+
+Possible Reasons
+
+- Your API key doesn't have write permissions
+- You're trying to update a protected artist record
+- You've reached your quota limit",
           },
         },
         "securityUi": [
@@ -2987,7 +3103,17 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "OK",
+            "description": "Albums Found
+
+The request was successful and returns a list of albums for the specified artist.
+
+Response Format
+
+The response includes:
+- A \`data\` array containing album objects
+- Pagination information for navigating through large collections
+
+> **Note:** If the artist has no albums, the data array will be empty but the request will still return a 200 status code.",
           },
         },
         "security": [
@@ -3319,7 +3445,18 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "Created",
+            "description": "Album Created Successfully
+
+The album has been successfully added to the artist's discography.
+
+Response Details
+
+The response includes the complete album object with:
+- A newly assigned unique \`id\`
+- All the information you provided in the request
+- The association with the artist
+
+",
           },
           "400": {
             "content": {
@@ -3425,7 +3562,17 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "Bad Request",
+            "description": "Bad Request
+
+The server could not process your request due to invalid album data.
+
+Common Causes
+
+- Missing required fields (title, year)
+- Invalid year format (must be a number)
+- Year out of valid range
+
+> **Tip:** Make sure the album year is accurate and in the correct format.",
           },
           "403": {
             "content": {
@@ -3531,7 +3678,15 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "Forbidden",
+            "description": "Forbidden
+
+You don't have permission to add albums to this artist.
+
+Possible Reasons
+
+- Your API key doesn't have write permissions
+- The artist's discography is locked or protected
+- You've reached your quota for album additions",
           },
         },
         "securityUi": [
@@ -3844,7 +3999,15 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "Created",
+            "description": "User Created Successfully
+
+Your account has been created and you can now access the Argentine Rock Legends API.
+
+Response Details
+
+The response includes your user information (excluding the password) and your API key for authentication.
+
+> **Important:** Save your API key securely as it will be needed for authenticated requests.",
           },
           "400": {
             "content": {
@@ -3950,7 +4113,18 @@ curl_close($ch);",
                 },
               },
             },
-            "description": "Bad Request",
+            "description": "Registration Failed
+
+The server could not process your registration request.
+
+Common Causes
+
+- Email address already in use
+- Missing required fields
+- Password doesn't meet security requirements
+- Invalid email format
+
+> **Tip:** Make sure your email is valid and your password is at least 8 characters long.",
           },
         },
         "security": [


### PR DESCRIPTION
According to the OpenAPI spec, Markdown **may** be used in the description field [of the Response Object](https://spec.openapis.org/oas/latest.html#response-object).

But the `OAResponse` component rendered the description as plain text.

Considering that descriptions across the whole UI are rendered with `OAMarkdown`, this is probably just a small oversight. This PR updates the Response descriptions to be rendered by the `OAMarkdown` component as well.

UI Before:

<img width="500" height="366" alt="2025-07-15--20-34-33--264" src="https://github.com/user-attachments/assets/0816521a-bb80-47e3-8a1b-f5dcd32dec6b" />

UI After:

<img width="500" height="460" alt="image" src="https://github.com/user-attachments/assets/abd559c4-f897-4e13-96de-c1c8ce0533ff" />