### PR TITLE
fix: display the complete UI for array items of primitive type

### DIFF
--- a/docs/public/openapi-schemas.json
+++ b/docs/public/openapi-schemas.json
@@ -5,6 +5,25 @@
     "version": "1.0.0"
   },
   "paths": {
+    "/tags-array": {
+      "get": {
+        "summary": "Get a tags array",
+        "operationId": "getTagsArray",
+        "description": "Example of a JSON object with an array of tags using items schema.",
+        "responses": {
+          "200": {
+            "description": "An object containing an array of tags",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagsObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/circular-reference": {
       "get": {
         "summary": "Get a parent",
@@ -202,6 +221,45 @@
   },
   "components": {
     "schemas": {
+      "TagsObject": {
+        "type": "object",
+        "properties": {
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "tag name",
+              "maxLength": 30
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "numbers": {
+                "type": "array",
+                "items": {
+                  "type": "number",
+                  "description": "A number associated with the tag"
+                }
+              }
+            }
+          }
+        },
+        "example": {
+          "tags": [
+            "important",
+            "featured",
+            "new",
+            "sale"
+          ],
+          "metadata": {
+            "extraTags": [
+              "limited",
+              "exclusive"
+            ]
+          }
+        }
+      },
       "Parent": {
         "type": "object",
         "properties": {
@@ -445,7 +503,10 @@
         }
       },
       "NullableObject": {
-        "type": ["object", "null"],
+        "type": [
+          "object",
+          "null"
+        ],
         "properties": {
           "id": {
             "type": "string"
@@ -497,7 +558,11 @@
             "items": {
               "type": "string"
             },
-            "example": ["tag1", "tag2", "tag3"]
+            "example": [
+              "tag1",
+              "tag2",
+              "tag3"
+            ]
           }
         ],
         "minItems": 5,
@@ -522,7 +587,11 @@
               },
               "role": {
                 "type": "string",
-                "enum": ["admin", "user", "guest"],
+                "enum": [
+                  "admin",
+                  "user",
+                  "guest"
+                ],
                 "example": "admin"
               }
             }
@@ -546,7 +615,10 @@
               "items": {
                 "type": "string"
               },
-              "example": ["important", "reviewed"]
+              "example": [
+                "important",
+                "reviewed"
+              ]
             }
           }
         },
@@ -560,18 +632,26 @@
           {
             "timestamp": "2023-01-15T14:30:00Z",
             "value": 42.5,
-            "tags": ["important", "reviewed"]
+            "tags": [
+              "important",
+              "reviewed"
+            ]
           },
           {
             "timestamp": "2023-01-16T09:15:00Z",
             "value": 17.8,
-            "tags": ["pending"]
+            "tags": [
+              "pending"
+            ]
           }
         ]
       },
       "ComplexRequest": {
         "type": "object",
-        "required": ["id", "data"],
+        "required": [
+          "id",
+          "data"
+        ],
         "properties": {
           "id": {
             "type": "string",
@@ -590,16 +670,24 @@
               {
                 "type": "object",
                 "description": "User data",
-                "required": ["type", "user"],
+                "required": [
+                  "type",
+                  "user"
+                ],
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["user"],
+                    "enum": [
+                      "user"
+                    ],
                     "example": "user"
                   },
                   "user": {
                     "type": "object",
-                    "required": ["id", "name"],
+                    "required": [
+                      "id",
+                      "name"
+                    ],
                     "properties": {
                       "id": {
                         "type": "string",
@@ -621,16 +709,25 @@
               {
                 "type": "object",
                 "description": "Product data",
-                "required": ["type", "product"],
+                "required": [
+                  "type",
+                  "product"
+                ],
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["product"],
+                    "enum": [
+                      "product"
+                    ],
                     "example": "product"
                   },
                   "product": {
                     "type": "object",
-                    "required": ["id", "name", "price"],
+                    "required": [
+                      "id",
+                      "name",
+                      "price"
+                    ],
                     "properties": {
                       "id": {
                         "type": "string",
@@ -656,16 +753,24 @@
               {
                 "type": "object",
                 "description": "Order data",
-                "required": ["type", "order"],
+                "required": [
+                  "type",
+                  "order"
+                ],
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["order"],
+                    "enum": [
+                      "order"
+                    ],
                     "example": "order"
                   },
                   "order": {
                     "type": "object",
-                    "required": ["id", "items"],
+                    "required": [
+                      "id",
+                      "items"
+                    ],
                     "properties": {
                       "id": {
                         "type": "string",
@@ -678,7 +783,10 @@
                         "type": "array",
                         "items": {
                           "type": "object",
-                          "required": ["productId", "quantity"],
+                          "required": [
+                            "productId",
+                            "quantity"
+                          ],
                           "properties": {
                             "productId": {
                               "type": "string",
@@ -712,7 +820,9 @@
             "anyOf": [
               {
                 "type": "object",
-                "required": ["source"],
+                "required": [
+                  "source"
+                ],
                 "properties": {
                   "source": {
                     "type": "string",
@@ -723,11 +833,17 @@
               },
               {
                 "type": "object",
-                "required": ["priority"],
+                "required": [
+                  "priority"
+                ],
                 "properties": {
                   "priority": {
                     "type": "string",
-                    "enum": ["low", "medium", "high"],
+                    "enum": [
+                      "low",
+                      "medium",
+                      "high"
+                    ],
                     "description": "Priority level",
                     "example": "high"
                   }
@@ -735,7 +851,9 @@
               },
               {
                 "type": "object",
-                "required": ["tags"],
+                "required": [
+                  "tags"
+                ],
                 "properties": {
                   "tags": {
                     "type": "array",
@@ -743,7 +861,11 @@
                       "type": "string"
                     },
                     "description": "Tags for categorization",
-                    "example": ["important", "sales", "follow-up"]
+                    "example": [
+                      "important",
+                      "sales",
+                      "follow-up"
+                    ]
                   }
                 }
               }
@@ -775,13 +897,20 @@
           "metadata": {
             "source": "web",
             "priority": "high",
-            "tags": ["important", "sales"]
+            "tags": [
+              "important",
+              "sales"
+            ]
           }
         }
       },
       "ComplexResponse": {
         "type": "object",
-        "required": ["id", "status", "result"],
+        "required": [
+          "id",
+          "status",
+          "result"
+        ],
         "properties": {
           "id": {
             "type": "string",
@@ -790,7 +919,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["success", "partial", "error"],
+            "enum": [
+              "success",
+              "partial",
+              "error"
+            ],
             "description": "Status of the response",
             "example": "success"
           },
@@ -800,18 +933,25 @@
               {
                 "type": "object",
                 "description": "Success result",
-                "required": ["type", "data"],
+                "required": [
+                  "type",
+                  "data"
+                ],
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["success"],
+                    "enum": [
+                      "success"
+                    ],
                     "example": "success"
                   },
                   "data": {
                     "anyOf": [
                       {
                         "type": "object",
-                        "required": ["user"],
+                        "required": [
+                          "user"
+                        ],
                         "properties": {
                           "user": {
                             "type": "object",
@@ -824,11 +964,16 @@
                                 "oneOf": [
                                   {
                                     "type": "object",
-                                    "required": ["type", "personal"],
+                                    "required": [
+                                      "type",
+                                      "personal"
+                                    ],
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["personal"],
+                                        "enum": [
+                                          "personal"
+                                        ],
                                         "example": "personal"
                                       },
                                       "personal": {
@@ -852,11 +997,16 @@
                                   },
                                   {
                                     "type": "object",
-                                    "required": ["type", "business"],
+                                    "required": [
+                                      "type",
+                                      "business"
+                                    ],
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["business"],
+                                        "enum": [
+                                          "business"
+                                        ],
                                         "example": "business"
                                       },
                                       "business": {
@@ -886,7 +1036,9 @@
                       },
                       {
                         "type": "object",
-                        "required": ["transaction"],
+                        "required": [
+                          "transaction"
+                        ],
                         "properties": {
                           "transaction": {
                             "type": "object",
@@ -907,11 +1059,16 @@
                                 "oneOf": [
                                   {
                                     "type": "object",
-                                    "required": ["type", "card"],
+                                    "required": [
+                                      "type",
+                                      "card"
+                                    ],
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["card"],
+                                        "enum": [
+                                          "card"
+                                        ],
                                         "example": "card"
                                       },
                                       "card": {
@@ -939,11 +1096,16 @@
                                   },
                                   {
                                     "type": "object",
-                                    "required": ["type", "bankTransfer"],
+                                    "required": [
+                                      "type",
+                                      "bankTransfer"
+                                    ],
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["bankTransfer"],
+                                        "enum": [
+                                          "bankTransfer"
+                                        ],
                                         "example": "bankTransfer"
                                       },
                                       "bankTransfer": {
@@ -968,11 +1130,16 @@
                                   },
                                   {
                                     "type": "object",
-                                    "required": ["type", "digitalWallet"],
+                                    "required": [
+                                      "type",
+                                      "digitalWallet"
+                                    ],
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["digitalWallet"],
+                                        "enum": [
+                                          "digitalWallet"
+                                        ],
                                         "example": "digitalWallet"
                                       },
                                       "digitalWallet": {
@@ -1004,16 +1171,24 @@
               {
                 "type": "object",
                 "description": "Error result",
-                "required": ["type", "error"],
+                "required": [
+                  "type",
+                  "error"
+                ],
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["error"],
+                    "enum": [
+                      "error"
+                    ],
                     "example": "error"
                   },
                   "error": {
                     "type": "object",
-                    "required": ["code", "message"],
+                    "required": [
+                      "code",
+                      "message"
+                    ],
                     "properties": {
                       "code": {
                         "type": "string",
@@ -1051,7 +1226,9 @@
             "anyOf": [
               {
                 "type": "object",
-                "required": ["processingTime"],
+                "required": [
+                  "processingTime"
+                ],
                 "properties": {
                   "processingTime": {
                     "type": "number",
@@ -1062,7 +1239,9 @@
               },
               {
                 "type": "object",
-                "required": ["region"],
+                "required": [
+                  "region"
+                ],
                 "properties": {
                   "region": {
                     "type": "string",
@@ -1073,7 +1252,9 @@
               },
               {
                 "type": "object",
-                "required": ["version"],
+                "required": [
+                  "version"
+                ],
                 "properties": {
                   "version": {
                     "type": "string",
@@ -1116,11 +1297,16 @@
       },
       "ErrorResponse": {
         "type": "object",
-        "required": ["error"],
+        "required": [
+          "error"
+        ],
         "properties": {
           "error": {
             "type": "object",
-            "required": ["code", "message"],
+            "required": [
+              "code",
+              "message"
+            ],
             "properties": {
               "code": {
                 "type": "string",
@@ -1136,7 +1322,10 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["field", "message"],
+                  "required": [
+                    "field",
+                    "message"
+                  ],
                   "properties": {
                     "field": {
                       "type": "string",

--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -57,7 +57,18 @@ const toggleAllChildren = (expand) => {
 const isObject = props.property.types?.includes('object')
 const isArray = props.property.types?.includes('array')
 const isObjectOrArray = isObject || isArray || props.property.type === 'object' || props.property.type === 'array'
-const isCollapsible = computed(() => isObjectOrArray && props.property.properties)
+const isCollapsible = computed(() =>
+  isObjectOrArray && (props.property.properties || props.property.items))
+
+const childProperties = computed(() => {
+  if (props.property.properties) {
+    return props.property.properties
+  }
+  if (props.property.items) {
+    return [props.property.items]
+  }
+  return []
+})
 const isUnion = props.property.meta?.isOneOf === true || props.property.meta?.isAnyOf === true
 
 const hasExpandableProperties = computed(() => {
@@ -212,7 +223,7 @@ const enumAttr = computed(() => ({ [t('Valid values')]: props.property.enum }))
 
         <div class="flex flex-col space-y-2">
           <OASchemaUI
-            v-for="(subProperty, idx) in props.property.properties"
+            v-for="(subProperty, idx) in childProperties"
             :key="idx"
             :property="subProperty"
             :schema="props.schema"

--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -71,13 +71,13 @@ const childProperties = computed(() => {
 })
 const isUnion = props.property.meta?.isOneOf === true || props.property.meta?.isAnyOf === true
 
-const propertyHasNestedExpandableProperties = computed(() => {
+const hasNestedObjectProperties = computed(() => {
   return props.property.properties
     && props.property.properties.length > 0
     && props.property.properties.some(p => (p.types?.includes('object') || p.types?.includes('array') || p.type === 'object' || p.type === 'array') && p.properties)
 })
 
-const propertyHasNestedExpandableItems = computed(() => {
+const hasNestedArrayItems = computed(() => {
   return props.property && props.property.properties
     && props.property.properties.length > 0
     && props.property.properties.some((p) => {
@@ -85,9 +85,9 @@ const propertyHasNestedExpandableItems = computed(() => {
     })
 })
 
-const hasExpandableProperties = computed(() => {
+const hasNestedExpandableContent = computed(() => {
   return isObjectOrArray
-    && (propertyHasNestedExpandableProperties.value || propertyHasNestedExpandableItems.value)
+    && (hasNestedObjectProperties.value || hasNestedArrayItems.value)
 })
 
 const unionBadge = computed(() => {
@@ -175,7 +175,7 @@ const enumAttr = computed(() => ({ [t('Valid values')]: props.property.enum }))
             </div>
 
             <div
-              v-if="hasExpandableProperties"
+              v-if="hasNestedExpandableContent"
               class="flex items-center"
             >
               <TooltipProvider>

--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -71,11 +71,23 @@ const childProperties = computed(() => {
 })
 const isUnion = props.property.meta?.isOneOf === true || props.property.meta?.isAnyOf === true
 
-const hasExpandableProperties = computed(() => {
-  return isObjectOrArray
-    && props.property.properties
+const propertyHasNestedExpandableProperties = computed(() => {
+  return props.property.properties
     && props.property.properties.length > 0
     && props.property.properties.some(p => (p.types?.includes('object') || p.types?.includes('array') || p.type === 'object' || p.type === 'array') && p.properties)
+})
+
+const propertyHasNestedExpandableItems = computed(() => {
+  return props.property && props.property.properties
+    && props.property.properties.length > 0
+    && props.property.properties.some((p) => {
+      return p.items
+    })
+})
+
+const hasExpandableProperties = computed(() => {
+  return isObjectOrArray
+    && (propertyHasNestedExpandableProperties.value || propertyHasNestedExpandableItems.value)
 })
 
 const unionBadge = computed(() => {

--- a/src/lib/parser/getSchemaUi.ts
+++ b/src/lib/parser/getSchemaUi.ts
@@ -36,6 +36,7 @@ export interface OAProperty {
   docs?: DocumentationReference
   constraints?: Record<string, unknown>
   properties?: OAProperty[]
+  items?: OAProperty
   enum?: unknown[]
   subtype?: JSONSchemaType
   subexamples?: unknown[]
@@ -252,6 +253,24 @@ class UiPropertyFactory {
               meta: { ...(prop.meta || {}), [metaItemKey]: true },
             }
           })
+        }
+
+        // store primitive item details
+        if (
+          schemaType !== 'object'
+          && schemaType !== 'array'
+          && !schema.items.oneOf
+          && !schema.items.anyOf
+        ) {
+          const itemProperty = UiPropertyFactory.schemaToUiProperty('[item]', schema.items)
+          if (
+            itemProperty.description
+            || itemProperty.enum
+            || itemProperty.constraints
+            || itemProperty.docs
+          ) {
+            property.items = itemProperty
+          }
         }
       }
 

--- a/test/lib/processOpenAPI/getSchemaUi.test.ts
+++ b/test/lib/processOpenAPI/getSchemaUi.test.ts
@@ -1000,6 +1000,45 @@ const fixtures: Record<string, FixtureTest> = {
     },
   },
 
+  'array of strings with description and constraint': {
+    jsonSchema: {
+      type: 'object',
+      properties: {
+        tags: {
+          type: 'array',
+          items: {
+            type: 'string',
+            description: 'tag name',
+            maxLength: 30,
+          },
+        },
+      },
+    },
+    schemaUi: {
+      name: '',
+      types: ['object'],
+      required: false,
+      properties: [
+        {
+          name: 'tags',
+          types: ['array'],
+          required: false,
+          subtype: 'string',
+          items: {
+            name: '[item]',
+            types: ['string'],
+            required: false,
+            description: 'tag name',
+            constraints: { maxLength: 30 },
+          },
+        },
+      ],
+    },
+    schemaUiJson: {
+      tags: ['string'],
+    },
+  },
+
   'nested object schema': {
     jsonSchema: {
       type: 'object',


### PR DESCRIPTION
Currently, if the schema type is `"array"` and its `"items"` are of a primitive type like `"string"`, the UI doesn't display annotations for those item schemas.

### Example:

```json
{
  "type": "object",
  "properties": {
    "foo": {
      "type": "string",
      "description": "String with a constraint",
      "maxLength": 30
    },
    "bar": {
      "type": "array",
      "description": "An array where each item is a string with a constraint",
      "items": {
        "type": "string",
        "description": "String with a constraint",
        "maxLength": 30
      }
    },
    "baz": {
      "type": "string",
      "enum": ["red", "green"],
      "description": "Enum string"
    },
    "qux": {
      "type": "array",
      "items": {
        "type": "string",
        "enum": ["red", "green"],
        "description": "Enum string"
      },
      "description": "An array where each item is a enum string"
    },
    "grox": {
      "anyOf": [
        {
          "type": "string",
          "description": "String with a constraint",
          "maxLength": 30
        },
        {
          "type": "array",
          "items": {
            "type": "string",
            "description": "String with a constraint",
            "maxLength": 30
          }
        }
      ]
    }
  }
}
```

Currently rendered as:

<img width="400" height="790" alt="before" src="https://github.com/user-attachments/assets/b25a6165-299a-4e48-b29b-ed2cacf2bca0" />

Notice that for the `bar` and `qux` properties, as well as for the second subschema in the `anyOf` array inside `grox`, no information about array items is shown (other than their type).

### In this PR:

* A new optional `items` field was added to the `OAProperty` interface so item metadata can be stored for array properties
* Primitive array item details are now recorded and attached to `property.items` (only when relevant) with the name `[item]`
* `OASchemaUI` was updated to treat either `properties` or `items` as children and loop through them when rendering sub-properties
* A new test fixture was added to verify that arrays of primitive items show item descriptions and constraints

### After the fix:

<img width="400" height="1106" alt="after" src="https://github.com/user-attachments/assets/652d4c36-ede1-4967-b446-3d94fe00c216" />