### PR TITLE
fix: adjust conditions to display "Expand" button

### DIFF
--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -57,8 +57,18 @@ const toggleAllChildren = (expand) => {
 const isObject = props.property.types?.includes('object')
 const isArray = props.property.types?.includes('array')
 const isObjectOrArray = isObject || isArray || props.property.type === 'object' || props.property.type === 'array'
-const isCollapsible = computed(() =>
-  isObjectOrArray && (props.property.properties || props.property.items))
+const isCollapsible = computed(() => {
+  if (!isObjectOrArray) {
+    return false
+  }
+  if (Array.isArray(props.property.properties) && props.property.properties.length > 0) {
+    return true
+  }
+  if (props.property.items) {
+    return true
+  }
+  return false
+})
 
 const childProperties = computed(() => {
   if (props.property.properties) {
@@ -110,7 +120,7 @@ const enumAttr = computed(() => ({ [t('Valid values')]: props.property.enum }))
   <div>
     <Collapsible
       v-model:open="isOpen"
-      :disabled="!isObjectOrArray"
+      :disabled="!isCollapsible"
     >
       <CollapsibleTrigger class="w-full">
         <div
@@ -225,7 +235,7 @@ const enumAttr = computed(() => ({ [t('Valid values')]: props.property.enum }))
 
       <OASchemaPropertyAttributes v-if="props.property.constraints" :property="props.property.constraints" />
 
-      <template v-if="isObjectOrArray && props.property?.description">
+      <template v-if="isCollapsible && props.property?.description">
         <CollapsibleTrigger>
           <Button
             as="div"


### PR DESCRIPTION
This adjusts the `isCollapsible` logic in `OASchemaUI.vue` so that the `<Collapsible>` component and "Expand" button are only enabled when there is actually something to expand or collapse.

In particular, it affects cases where the schema is an array but has no nested properties to display:

```json
{
  "case1": {
    "type": "array",
    "items": {
      "type": "object"
    },
    "description": "Array of objects without properties"
  },
  "case2": {
    "type": "array",
    "items": {
      "type": "string"
    },
    "description": "Array of strings"
  }
}
```

Before:

<img width="500" alt="2025-07-26--10-05-55--007" src="https://github.com/user-attachments/assets/89acccf8-4c21-41e3-b0c3-085d610c8df8" />

After:

<img width="500" alt="2025-07-26--10-05-41--913" src="https://github.com/user-attachments/assets/d890ef82-c4e2-41fb-951e-8407743cd127" />
