### PR TITLE
fix: remove redundant `t()` call in OASchemaUI.vue

### DIFF
--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -113,7 +113,7 @@ const toggleLabel = computed(() => isOpen.value ? t('Collapse') : t('Expand'))
 
 const toggleAllLabel = computed(() => isOpen.value ? t('Collapse all') : t('Expand all'))
 
-const enumAttr = computed(() => ({ [t('Valid values')]: props.property.enum }))
+const enumAttr = computed(() => ({ 'Valid values': props.property.enum }))
 </script>
 
 <template>


### PR DESCRIPTION
Since we always call `t(titleCase(key))` in `OASchemaPropertyAttributes.vue`, wrapping `'Valid values'` in one more `t('Valid values')` call in `OASchemaUI.vue` is unnecessary and leads to console warnings like

```sh
[vue-i18n] Message "Valores válidos" not found  
```

when using a locale other than `en`.

A small oversight introduced by #267.

This PR fixes it by removing redundant call in `OASchemaUI.vue`.