### PR TITLE
fix: respect `schemaViewer.deep` option in OASchemaUI

### DIFF
--- a/docs/composables/useTheme.md
+++ b/docs/composables/useTheme.md
@@ -27,7 +27,7 @@ export default {
                 renderer: 'vue-json-pretty', // vue-json-pretty or shiki
             },
             schemaViewer: {
-                // How many levels are expanded on load. Maximum is 10.
+                // How many levels are expanded on load.
                 deep: 1,
             },
             // Set the heading levels.

--- a/docs/composables/useTheme.md
+++ b/docs/composables/useTheme.md
@@ -21,14 +21,14 @@ export default {
                 defaultView: 'schema', // schema or contentType
             },
             jsonViewer: {
-                // Set the JSON viewer depth.
+                // How many levels are expanded on load.
                 deep: Infinity,
                 // Set the JSON viewer renderer.
                 renderer: 'vue-json-pretty', // vue-json-pretty or shiki
             },
             schemaViewer: {
-                // Set the schema viewer depth.
-                deep: Infinity,
+                // How many levels are expanded on load. Maximum is 10.
+                deep: 1,
             },
             // Set the heading levels.
             headingLevels: {

--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -269,7 +269,7 @@ const enumAttr = computed(() => ({ 'Valid values': props.property.enum }))
             :schema="props.schema"
             :deep="props.deep - 1"
             :level="props.level + 1"
-            :open="childrenExpandState !== undefined ? childrenExpandState : isUnion"
+            :open="childrenExpandState !== undefined ? childrenExpandState : (isUnion ? true : undefined)"
             :expand-all="childrenExpandState"
           />
         </div>

--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -38,7 +38,7 @@ const props = defineProps({
 
 const { t } = useI18n()
 
-const isOpen = ref(props.open !== undefined ? props.open : props.deep > 0 && props.level <= 10)
+const isOpen = ref(props.open !== undefined ? props.open : props.deep > 0 && props.level <= props.deep)
 
 const childrenExpandState = ref(undefined)
 

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -263,7 +263,7 @@ const defaultValues = {
     renderer: 'vue-json-pretty' as JsonRendererType,
   },
   schemaViewer: {
-    deep: 1,
+    deep: Number.POSITIVE_INFINITY,
   },
   headingLevels: {
     h1: 1,

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -263,7 +263,7 @@ const defaultValues = {
     renderer: 'vue-json-pretty' as JsonRendererType,
   },
   schemaViewer: {
-    deep: Number.POSITIVE_INFINITY,
+    deep: 1,
   },
   headingLevels: {
     h1: 1,

--- a/test/composables/useTheme.test.ts
+++ b/test/composables/useTheme.test.ts
@@ -212,7 +212,7 @@ describe('initialization and reset', () => {
 
     expect(theme.getJsonViewerDeep()).toBe(Number.POSITIVE_INFINITY)
     expect(theme.getJsonViewerRenderer()).toBe('vue-json-pretty')
-    expect(theme.getSchemaViewerDeep()).toBe(Number.POSITIVE_INFINITY)
+    expect(theme.getSchemaViewerDeep()).toBe(1)
     expect(theme.getHeadingLevels()).toEqual({
       h1: 1,
       h2: 2,
@@ -386,7 +386,7 @@ describe('jSON and Schema viewers', () => {
 
   it('returns the default schemaViewer deep value', () => {
     const result = themeConfig.getSchemaViewerDeep()
-    expect(result).toBe(Number.POSITIVE_INFINITY)
+    expect(result).toBe(1)
   })
 
   it('sets and gets the schemaViewer deep value', () => {


### PR DESCRIPTION
Currently, in `OASchemaUI.vue`, the open state for each child component is determined by the `open` prop. This prop is set with the expression:

```vue
<OASchemaUI
  ...
  :open="childrenExpandState !== undefined ? childrenExpandState : isUnion"
  ...
/>
```

Because this expression always yields a boolean (either `childrenExpandState` when defined or `isUnion` when not), the `open` prop is never `undefined` for nested schemas. Consequently, `isOpen` is always initialized using this provided value instead of using `props.deep` logic:

```ts
const isOpen = ref(props.open !== undefined ? props.open : props.deep > 0 && props.level <= 10)
```

This makes the configuration option `schemaViewer.deep` useless, as it doesn't affect the rendering of OASchemaUI in any way.

This PR:
* Fixes that by passing `undefined` to nested `<OASchemaUI>` components when appropriate
* Clarifies the wording in `docs/composables/useTheme.md` to make it clearer what exactly this option does

Also it:
* Sets the default value of `schemaViewer.deep` to `1`, which effectively replicates the current behavior (since schemas can't be expanded more than 1 level deep regardless of the default `Infinity` value)
* Updates tests to expect `1` whenever the default value for that option appears
