### PR TITLE
fix: Make labels used in `OAParameter` align with those in `OASchemaUI`

### DIFF
--- a/src/components/Parameter/OAParameter.vue
+++ b/src/components/Parameter/OAParameter.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { useI18n } from '@byjohann/vue-i18n'
+import { titleCase } from 'scule'
 import { getConstraints } from '../../lib/parser/constraintsParser'
 import OACodeValue from '../Common/OACodeValue.vue'
 import OAMarkdown from '../Common/OAMarkdown.vue'
@@ -53,7 +54,7 @@ const { t } = useI18n()
         >{{ t('Required') }}</span>
       </div>
 
-      <OAParameterAttribute v-if="props.parameter.schema.enum" :name="t('Enum')" :value="props.parameter.schema.enum.join(', ')">
+      <OAParameterAttribute v-if="props.parameter.schema.enum" :name="t('Valid values')" :value="props.parameter.schema.enum.join(', ')">
         <template #value>
           <div class="flex flex-wrap gap-2">
             <OACodeValue
@@ -71,7 +72,7 @@ const { t } = useI18n()
         <OAParameterAttribute
           v-for="(value, name) in constraints"
           :key="name"
-          :name="name"
+          :name="t(titleCase(name))"
         >
           <template #value>
             <OACodeValue :value="value" />


### PR DESCRIPTION
Currently, there is some level of inconsistency between labels in `OAParameter` and `OASchemaUI`. For example:

When the Parameter Object uses a schema with the `"enum"` field, the Parameter UI shows `Enum` label, while the identical schema in the Request/Response body uses `Valid values` phrase.

Additionally, for property attributes such as `default`, `maxLength`, etc., there was no internationalization. As a result, where the Request/Response body shows "Por defecto" (e.g., in `es` locale), the Parameter UI shows "default" (non-localized), which adds more inconsistency.

This PR fixes this by replacing `t('Enum')` with `t('Valid values')` in `OAParameter.vue` (aligned with `OASchemaUI.vue`) and passing `name` (parameter attribute name) to `t(titleCase(name))`, which is identical to how `OASchemaUI.vue` handles it.

Before:

<img width="500" alt="2025-07-28--11-52-04--033" src="https://github.com/user-attachments/assets/3a0ca81e-b669-4665-8939-7395a3ddb5f8" />

After:

<img width="500" alt="2025-07-28--11-52-42--933" src="https://github.com/user-attachments/assets/a7d846a1-5bf6-4102-96d3-d90183a023d8" />
