### PR TITLE
fix: Wrap the schema property heading when there is not enough space

### DIFF
--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -129,7 +129,7 @@ const enumAttr = computed(() => ({ 'Valid values': props.property.enum }))
             'cursor-pointer': isCollapsible,
           }"
         >
-          <div class="flex flex-row items-center gap-2 text-sm">
+          <div class="flex flex-row flex-wrap items-center gap-2 text-sm">
             <span
               v-if="props.property.name && props.property.name.trim() !== ''"
               class="font-bold"


### PR DESCRIPTION
There is a problem with the layout in the schema UI property heading row (which shows the property name, type, and the `Required` label) when the container width is small, because that row cannot be wrapped, so it overflows the screen and its flex container for the type breaks.

This PR solves it by making the row wrappable with `flex-wrap`. This is how it looks:

Before:

<img width="393"  alt="2025-07-28--10-38-28--211" src="https://github.com/user-attachments/assets/d30abef0-a1c5-41ac-b48a-b3018c8b70b9" />

After:

<img width="393"  alt="2025-07-28--10-39-40--442" src="https://github.com/user-attachments/assets/ce015b20-a72c-4757-8953-28fa1db291fa" />

Not 100% perfect, since depending on the property name length, the types it has, and whether it is required or not, the `Required` label alignment when it's wrapped may be different (left or right side of the container). So, for a perfect solution, additional styling with conditionally applied flexbox utilities is probably needed.
