### PR TITLE
fix(types): implement localStorage availability check

### DIFF
--- a/src/components/Feature/OAOperationContext.vue
+++ b/src/components/Feature/OAOperationContext.vue
@@ -7,6 +7,7 @@ import { useTheme } from '../../composables/useTheme'
 import { buildRequest } from '../../lib/codeSamples/buildRequest'
 import { initOperationData, OPERATION_DATA_KEY } from '../../lib/operationData'
 import { resolveBaseUrl } from '../../lib/resolveBaseUrl'
+import { isLocalStorageAvailable } from '../../lib/utils'
 
 const props = defineProps({
   operationId: {
@@ -53,7 +54,7 @@ const defaultServer = computed(
     : themeConfig.getOperationDefaultBaseUrl(),
 )
 
-const customServer = typeof localStorage !== 'undefined'
+const customServer = isLocalStorageAvailable()
   ? useStorage('--oa-custom-server-url', null, localStorage)
   : ref(defaultServer.value)
 

--- a/src/components/Playground/OAPlaygroundParameters.vue
+++ b/src/components/Playground/OAPlaygroundParameters.vue
@@ -12,6 +12,7 @@ import { buildRequest } from '../../lib/codeSamples/buildRequest'
 import { getPropertyExample } from '../../lib/examples/getPropertyExample'
 import { OPERATION_DATA_KEY } from '../../lib/operationData'
 import { createCompositeKey } from '../../lib/playground/createCompositeKey'
+import { isLocalStorageAvailable } from '../../lib/utils'
 import OAPlaygroundBodyInput from '../Playground/OAPlaygroundBodyInput.vue'
 import OAPlaygroundParameterInput from '../Playground/OAPlaygroundParameterInput.vue'
 import OAPlaygroundSecurityInput from '../Playground/OAPlaygroundSecurityInput.vue'
@@ -96,7 +97,7 @@ const request = computed({
 
 const allowCustomServer = computed(() => useTheme().getServerAllowCustomServer())
 
-const useCustomServer = typeof localStorage !== 'undefined'
+const useCustomServer = isLocalStorageAvailable()
   ? useStorage('--oa-use-custom-server', allowCustomServer.value, localStorage)
   : ref(false)
 
@@ -116,7 +117,7 @@ const serversUrls: ComputedRef<string[]> = computed(() =>
     .filter(value => value !== undefined),
 )
 
-const customServer = typeof localStorage !== 'undefined'
+const customServer = isLocalStorageAvailable()
   ? useStorage('--oa-custom-server-url', selectedServer.value, localStorage)
   : ref(selectedServer.value)
 
@@ -198,7 +199,7 @@ watch(selectedSchemeId, (schemeId) => {
       scheme: scheme.scheme,
       in: scheme.in,
       name: scheme.name ?? name,
-      value: typeof localStorage !== 'undefined'
+      value: isLocalStorageAvailable()
         ? useStorage(`--oa-authorization-${name}`, example, localStorage)
         : example,
       label: name,

--- a/src/lib/operationData.ts
+++ b/src/lib/operationData.ts
@@ -4,6 +4,7 @@ import type { OARequest } from './codeSamples/request'
 import { useStorage } from '@vueuse/core'
 import { ref } from 'vue'
 import { useTheme } from '../composables/useTheme'
+import { isLocalStorageAvailable } from './utils'
 
 export interface OperationData {
   operationId: string
@@ -44,7 +45,7 @@ export function initOperationData({
     },
     playground: {
       request: ref(request || {} as OARequest),
-      selectedServer: typeof localStorage !== 'undefined'
+      selectedServer: isLocalStorageAvailable()
         ? useStorage(`--oa-operation-${operation.operationId}-selectedServer`, selectedServer, localStorage, {
             mergeDefaults: true,
           })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,6 +6,10 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+export function isLocalStorageAvailable(): boolean {
+  return typeof localStorage !== 'undefined' && typeof localStorage.getItem === 'function'
+}
+
 export function scrollToHash({
   hash,
 }: {

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { isLocalStorageAvailable } from '../../src/lib/utils'
+
+describe('utils', () => {
+  describe('isLocalStorageAvailable', () => {
+    const originalLocalStorage = globalThis.localStorage
+
+    afterEach(() => {
+      if (originalLocalStorage) {
+        Object.defineProperty(globalThis, 'localStorage', {
+          value: originalLocalStorage,
+          writable: true,
+          configurable: true,
+        })
+      }
+      else {
+        delete (globalThis as any).localStorage
+      }
+    })
+
+    it('should return false when localStorage is undefined', () => {
+      delete (globalThis as any).localStorage
+      expect(isLocalStorageAvailable()).toBe(false)
+    })
+
+    it('should return false when localStorage exists but getItem is not a function (Node v25 behavior)', () => {
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: {},
+        writable: true,
+        configurable: true,
+      })
+      expect(isLocalStorageAvailable()).toBe(false)
+    })
+
+    it('should return false when localStorage.getItem is undefined', () => {
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: { getItem: undefined },
+        writable: true,
+        configurable: true,
+      })
+      expect(isLocalStorageAvailable()).toBe(false)
+    })
+
+    it('should return false when localStorage.getItem is not a function', () => {
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: { getItem: 'not a function' },
+        writable: true,
+        configurable: true,
+      })
+      expect(isLocalStorageAvailable()).toBe(false)
+    })
+
+    it('should return true when localStorage has a proper getItem function', () => {
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: {
+          getItem: vi.fn(),
+          setItem: vi.fn(),
+          removeItem: vi.fn(),
+          clear: vi.fn(),
+        },
+        writable: true,
+        configurable: true,
+      })
+      expect(isLocalStorageAvailable()).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

Fix `TypeError: n.getItem is not a function` error that occurs during SSR build in Node.js v25.

In Node.js v25, `localStorage` exists as an object but without the `getItem`/`setItem` methods implemented. The previous check `typeof localStorage !== 'undefined'` passed, but then failed when calling `localStorage.getItem()`.

## Related issues/external references

Fixes #309 

## Types of changes

- Bug fix