### PR TITLE
fix: resolve nested properties for additionalProperties schemas

### DIFF
--- a/src/lib/parser/getSchemaUi.ts
+++ b/src/lib/parser/getSchemaUi.ts
@@ -234,6 +234,7 @@ class UiPropertyFactory {
               schema.items.properties,
               schema.items.required || [],
               schema.items.additionalProperties,
+              schema.items['x-additionalPropertiesName'],
             )
           : undefined
 
@@ -334,6 +335,7 @@ class UiPropertyFactory {
         schema.properties,
         schema.required || [],
         schema.additionalProperties,
+        schema['x-additionalPropertiesName'],
       )
     } else if (schema.type === undefined) {
       if (schema.properties || schema.additionalProperties) {
@@ -342,6 +344,7 @@ class UiPropertyFactory {
           schema.properties,
           schema.required || [],
           schema.additionalProperties,
+          schema['x-additionalPropertiesName'],
         )
       }
     }
@@ -353,6 +356,7 @@ class UiPropertyFactory {
     propertiesNode?: Record<string, OpenAPI.SchemaObject>,
     requiredProperties: string[] = [],
     additionalPropertiesNode?: OpenAPI.SchemaObject | boolean,
+    additionalPropertiesName?: string,
   ): OAProperty[] {
     const properties: OAProperty[] = []
 
@@ -368,12 +372,11 @@ class UiPropertyFactory {
         ? additionalPropertiesNode
         : { type: 'string' }
 
-      properties.push({
-        name: 'additionalProperties',
-        types: [additionalProps.type as JSONSchemaType],
-        required: false,
-        meta: { isAdditionalProperties: true },
-      })
+      const name = additionalPropertiesName || 'additionalProperties'
+      const property = UiPropertyFactory.schemaToUiProperty(name, additionalProps)
+      property.required = false
+      property.meta = { ...(property.meta || {}), isAdditionalProperties: true }
+      properties.push(property)
     }
 
     return properties

--- a/test/lib/processOpenAPI/getSchemaUi.test.ts
+++ b/test/lib/processOpenAPI/getSchemaUi.test.ts
@@ -105,6 +105,85 @@ const fixtures: Record<string, FixtureTest> = {
     },
   },
 
+  'schema with additionalProperties referencing nested object': {
+    jsonSchema: {
+      type: 'object',
+      additionalProperties: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          active: { type: 'boolean' },
+        },
+      },
+    },
+    schemaUi: {
+      name: '',
+      properties: [
+        {
+          meta: {
+            isAdditionalProperties: true,
+          },
+          name: 'additionalProperties',
+          required: false,
+          types: ['object'],
+          properties: [
+            { name: 'name', types: ['string'], required: false },
+            { name: 'active', types: ['boolean'], required: false },
+          ],
+        },
+      ],
+      types: ['object'],
+      required: false,
+    },
+    schemaUiJson: {
+      additionalProperties: {
+        name: 'string',
+        active: true,
+      },
+    },
+  },
+
+  'schema with x-additionalPropertiesName': {
+    jsonSchema: {
+      type: 'object',
+      'x-additionalPropertiesName': '{key}',
+      additionalProperties: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+      },
+    },
+    schemaUi: {
+      name: '',
+      meta: {
+        extra: {
+          'x-additionalPropertiesName': '{key}',
+        },
+      },
+      properties: [
+        {
+          meta: {
+            isAdditionalProperties: true,
+          },
+          name: '{key}',
+          required: false,
+          types: ['object'],
+          properties: [
+            { name: 'name', types: ['string'], required: false },
+          ],
+        },
+      ],
+      types: ['object'],
+      required: false,
+    },
+    schemaUiJson: {
+      '{key}': {
+        name: 'string',
+      },
+    },
+  },
+
   'empty schema returns empty array': {
     jsonSchema: {},
     schemaUi: [],


### PR DESCRIPTION
Hi @enzonotario!
Here at [BANKSapi](https://banksapi.de/) we use your project and thank you very much for maintaining it. We have [one endpoint](https://docs.banksapi.de/api/banks-connect.html#AddBankAccess) relying heavily on `additionalProperties`, which is why we would like to support that a bit more. This is a current disadvantage from this OpenAPI visualization compared to Swagger-UI, where we come from.

Currently (a lot of info from the OpenAPI is missing, see next screenshot): 
<img width="554" height="280" alt="image" src="https://github.com/user-attachments/assets/a47fdb78-e8b4-421d-bf11-2f772e5101f9" />

After this PR (expandable and free "map-key" naming):
<img width="572" height="836" alt="image" src="https://github.com/user-attachments/assets/9846a812-efc4-401a-9155-b3fc1d35f243" />

And this is how it looks in Swagger-UI (just as a comparison):
<img width="585" height="633" alt="image" src="https://github.com/user-attachments/assets/8bf50090-c329-4b3a-a92d-4202fc642f5e" />


## Summary

- **Fix `additionalProperties` with complex schemas**: When `additionalProperties` references a `$ref` to an object schema with nested properties, only "additionalProperties object" was displayed. The root cause was `extractProperties()` manually constructing a minimal `OAProperty` using only the `type` field. Now routes through `schemaToUiProperty()` so nested structures are fully resolved.
- **Add `x-additionalPropertiesName` extension**: Allows schemas to specify a custom display name for the additionalProperties key (e.g. `{ACCESS_UUID}` instead of the generic `additionalProperties`), useful for map/dictionary schemas where the key has semantic meaning. This is also used by e.g. Redocly, see: https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-additional-properties-name

## Test plan

- [x] Existing `'schema with additionalProperties'` test still passes (simple string type)
- [x] New test for `additionalProperties` referencing a nested object with properties
- [x] New test for `x-additionalPropertiesName` custom naming
- [x] Full test suite passes (631 tests)