### PR TITLE
fix: avoid nested <button> in collapsible triggers causing hydration mismatch

### DIFF
--- a/src/components/Path/OAPathsGroup.vue
+++ b/src/components/Path/OAPathsGroup.vue
@@ -69,7 +69,7 @@ function onPathClick(hash: string) {
         class="flex justify-center"
       >
         <CollapsibleTrigger>
-          <Button>
+          <Button as="div">
             {{ isOpen ? t('Hide operations') : t('Show operations') }}
           </Button>
         </CollapsibleTrigger>

--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -142,6 +142,7 @@ const propertyName = computed(() => props.property.name || props.property.title)
                   <TooltipTrigger as-child>
                     <Button
                       v-if="isCollapsible"
+                      as="div"
                       size="icon"
                       variant="icon"
                       :aria-label="toggleLabel"
@@ -191,6 +192,7 @@ const propertyName = computed(() => props.property.name || props.property.title)
                 <Tooltip :delay-duration="200">
                   <TooltipTrigger as-child>
                     <Button
+                      as="div"
                       size="icon"
                       variant="icon"
                       :aria-label="toggleAllLabel"


### PR DESCRIPTION
## Summary

Fixes a hydration mismatch that appears in production builds when an OpenAPI operation renders schemas with `oneOf`/`anyOf` (and, more generally, on any page using collapsible operation groups).

Several controls were rendered as the default `<button>` while living **inside** a `CollapsibleTrigger`, which is itself a native `<button>`. This produces invalid nested-button markup (`<button>…<button>…</button>…</button>`). During SSR hydration the browser auto-closes the outer `<button>` and ejects the subsequent content out of its container, causing:

- `Hydration completed but contains mismatches` (Vue error)
- Visually duplicated sections (footer, try-it panel)
- Not visible in `dev` (SSR disabled), only in production build / preview

## Changes

Render these controls as `as="div"` to avoid nested buttons (following the pattern already used elsewhere in `OASchemaUI.vue`):

- `src/components/Schema/OASchemaUI.vue` — chevron indicator and collapse-all control
- `src/components/Path/OAPathsGroup.vue` — show/hide operations control

The interaction is preserved: the chevron and the show/hide control are toggled by the parent `CollapsibleTrigger`, and the collapse-all control keeps its `@click` handler (Vue attaches listeners regardless of tag).

## Test plan

- [x] Production build (`pnpm docs:build`) succeeds
- [x] Nested `<button>` in generated SSR HTML: 1 → 0 (verified across `tests/schemas`, `example/one-page`, `examples/scalar-galaxy`)
- [x] `Hydration completed but contains mismatches` errors in console: gone
- [x] Collapse/expand toggles still work
- [x] No visually duplicated sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)