### PR TITLE
feat(security): render OAuth2 refreshUrl and localize Scopes label

### DIFF
--- a/src/components/Security/OASecurityContent.vue
+++ b/src/components/Security/OASecurityContent.vue
@@ -81,8 +81,13 @@ const typeValue = computed(() => {
                 <OACodeValue :value="url.tokenUrl" />
               </div>
 
+              <div v-if="url.refreshUrl" class="flex flex-wrap gap-2">
+                <span class="text-sm">{{ t('Refresh URL') }}</span>
+                <OACodeValue :value="url.refreshUrl" />
+              </div>
+
               <div v-if="url.scopes">
-                <span class="text-sm">Scopes:</span>
+                <span class="text-sm">{{ t('Scopes') }}:</span>
                 <ul class="pl-2 my-0!">
                   <li
                     v-for="(description, scope) in url.scopes"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -53,6 +53,7 @@
   "Authorization URL": "Authorization URL",
   "Token URL": "Token URL",
   "Refresh URL": "Refresh URL",
+  "Scopes": "Scopes",
   "Select an example": "Select an example",
   "Playground": "Playground",
   "Collapse all": "Collapse all",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -53,6 +53,7 @@
   "Authorization URL": "URL de autorización",
   "Token URL": "URL del token",
   "Refresh URL": "URL de actualización",
+  "Scopes": "Ámbitos",
   "Select an example": "Selecciona un ejemplo",
   "Playground": "Playground",
   "Collapse all": "Colapsar todo",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -53,6 +53,7 @@
   "Authorization URL": "認可 URL",
   "Token URL": "トークン URL",
   "Refresh URL": "リフレッシュ URL",
+  "Scopes": "スコープ",
   "Select an example": "例を選択",
   "Playground": "Playground",
   "Collapse all": "すべて折りたたむ",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -53,6 +53,7 @@
   "Authorization URL": "URL de autorização",
   "Token URL": "URL do token",
   "Refresh URL": "URL de atualização",
+  "Scopes": "Escopos",
   "Select an example": "Selecione um exemplo",
   "Playground": "Playground",
   "Collapse all": "Recolher tudo",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -53,6 +53,7 @@
   "Authorization URL": "授权 URL",
   "Token URL": "令牌 URL",
   "Refresh URL": "刷新 URL",
+  "Scopes": "作用域",
   "Select an example": "选择示例",
   "Playground": "试验场",
   "Collapse all": "全部折叠",


### PR DESCRIPTION
## Summary

Follow-up to #334. Two OAuth2 security-scheme details were not going through i18n:

- The `refreshUrl` flow field was never rendered, even though the `Refresh URL` locale key already exists in the dictionaries (it was an unused entry).
- The `Scopes:` label in `OASecurityContent.vue` was hardcoded, so it could not be translated.

This PR:

- Renders `refreshUrl` for OAuth2 flows using the existing `t('Refresh URL')` key, so the key is no longer dead.
- Replaces the hardcoded `Scopes:` label with `{{ t('Scopes') }}:` and adds the `Scopes` key to every locale (`en`, `es`, `ja`, `pt-BR`, `zh`).

## Test plan

- [x] `pnpm run lint` clean.
- [x] `pnpm run build` passes (including `vue-tsc` declaration emit).
- [x] `pnpm run test:run` — 671 tests passing.
- [x] JSON validity of all locale files verified.