### PR TITLE
feat: add markdownToPlainText helper and expose operation description in getPathsByVerbs

### DIFF
--- a/docs/pages/by-operation.md
+++ b/docs/pages/by-operation.md
@@ -45,6 +45,48 @@ export default {
 }
 ```
 
+### Meta descriptions
+
+`getPathsByVerbs()` also exposes each operation's raw Markdown `description`. Combined with the `markdownToPlainText` helper, you can use it to generate a `<meta name="description">` for each page:
+
+```ts
+import { markdownToPlainText, usePaths } from 'vitepress-openapi'
+import spec from '../public/openapi.json' with {type: 'json'}
+
+export default {
+    paths() {
+        return usePaths({ spec })
+            .getPathsByVerbs()
+            .map(({ operationId, summary, description }) => {
+                return {
+                    params: {
+                        operationId,
+                        pageTitle: `${summary} - vitepress-openapi`,
+                        description: markdownToPlainText(description, { maxLength: 160 }),
+                    },
+                }
+            })
+    },
+}
+```
+
+`markdownToPlainText` reduces the Markdown (and any inline HTML) to a single line of plain text, truncated at a word boundary when `maxLength` is set.
+
+Then map the params onto the page data in your `.vitepress/config.[js,ts]` file, using the [transformPageData](https://vitepress.dev/reference/site-config#transformpagedata) hook:
+
+```ts
+export default defineConfig({
+    transformPageData(pageData) {
+        if (pageData.params?.pageTitle) {
+            pageData.title = pageData.params.pageTitle
+        }
+        if (pageData.params?.description) {
+            pageData.description = pageData.params.description
+        }
+    },
+})
+```
+
 ## Markdown File
 
 In the `[operationId].md` file, you can use the `OAOperation` component to render the operation.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ export {
 } from './composables/useOpenapi'
 export { usePaths } from './composables/usePaths'
 export { useSidebar } from './composables/useSidebar'
-export { createOpenApiSpec, type OpenApiSpecInstance } from './lib/spec/createOpenApiSpec'
 export { markdownToPlainText, type MarkdownToPlainTextOptions } from './lib/markdown/markdownToPlainText'
+export { createOpenApiSpec, type OpenApiSpecInstance } from './lib/spec/createOpenApiSpec'
 export { minifyHtml } from './lib/utils/minifyHtml'
 export { parseSpec } from './lib/utils/parseSpec'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
 export { usePaths } from './composables/usePaths'
 export { useSidebar } from './composables/useSidebar'
 export { createOpenApiSpec, type OpenApiSpecInstance } from './lib/spec/createOpenApiSpec'
+export { markdownToPlainText, type MarkdownToPlainTextOptions } from './lib/markdown/markdownToPlainText'
 export { minifyHtml } from './lib/utils/minifyHtml'
 export { parseSpec } from './lib/utils/parseSpec'
 

--- a/src/lib/markdown/markdownToPlainText.ts
+++ b/src/lib/markdown/markdownToPlainText.ts
@@ -1,0 +1,46 @@
+import MarkdownIt from 'markdown-it'
+
+const md = new MarkdownIt({ html: true })
+
+const HTML_ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': '\'',
+}
+
+export interface MarkdownToPlainTextOptions {
+  /**
+   * Maximum length of the returned text. When the plain text is longer, it is
+   * truncated at a word boundary and suffixed with an ellipsis, keeping the
+   * result within `maxLength` characters. Useful for `<meta name="description">`.
+   */
+  maxLength?: number
+}
+
+/**
+ * Reduces a Markdown string (optionally containing inline HTML) to a
+ * single-line plain-text string, e.g. to build meta descriptions for
+ * pages generated from OpenAPI operation descriptions.
+ */
+export function markdownToPlainText(
+  markdown: string | null | undefined,
+  options: MarkdownToPlainTextOptions = {},
+): string {
+  const text = md.render(markdown ?? '')
+    // Block boundaries and line breaks become spaces so adjacent blocks do not
+    // merge into one word; inline tags (<code>, <strong>, …) are removed
+    // without adding whitespace around their content.
+    .replace(/<\/(?:p|div|h[1-6]|li|blockquote|td|th|tr)>|<(?:br|hr)\s*\/?>/g, ' ')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&(?:amp|lt|gt|quot|#39);/g, entity => HTML_ENTITIES[entity])
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (options.maxLength === undefined || text.length <= options.maxLength) {
+    return text
+  }
+
+  return `${text.slice(0, options.maxLength - 1).replace(/\s*\S*$/, '')}…`
+}

--- a/src/lib/markdown/markdownToPlainText.ts
+++ b/src/lib/markdown/markdownToPlainText.ts
@@ -10,11 +10,25 @@ const HTML_ENTITIES: Record<string, string> = {
   '&#39;': '\'',
 }
 
+/** Block boundaries and void line-break tags → space between adjacent blocks. */
+const BLOCK_BOUNDARY_TAGS = /<\/(?:p|div|h[1-6]|li|blockquote|td|th|tr)>|<(?:br|hr)\s*\/?>/g
+
+/**
+ * Strip any HTML tag, allowing `>` inside quoted attribute values
+ * (e.g. `<span title="x > y">`).
+ */
+const HTML_TAGS = /<(?:"[^"]*"|'[^']*'|[^'">])*>/g
+
+const HTML_ENTITIES_PATTERN = /&(?:amp|lt|gt|quot|#39);/g
+const COLLAPSE_WHITESPACE = /\s+/g
+const TRAILING_PARTIAL_WORD = /\s*\S*$/
+
 export interface MarkdownToPlainTextOptions {
   /**
    * Maximum length of the returned text. When the plain text is longer, it is
    * truncated at a word boundary and suffixed with an ellipsis, keeping the
    * result within `maxLength` characters. Useful for `<meta name="description">`.
+   * Must be a non-negative integer when provided; `0` yields an empty string.
    */
   maxLength?: number
 }
@@ -32,15 +46,28 @@ export function markdownToPlainText(
     // Block boundaries and line breaks become spaces so adjacent blocks do not
     // merge into one word; inline tags (<code>, <strong>, …) are removed
     // without adding whitespace around their content.
-    .replace(/<\/(?:p|div|h[1-6]|li|blockquote|td|th|tr)>|<(?:br|hr)\s*\/?>/g, ' ')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&(?:amp|lt|gt|quot|#39);/g, entity => HTML_ENTITIES[entity])
-    .replace(/\s+/g, ' ')
+    .replace(BLOCK_BOUNDARY_TAGS, ' ')
+    .replace(HTML_TAGS, '')
+    .replace(HTML_ENTITIES_PATTERN, entity => HTML_ENTITIES[entity])
+    .replace(COLLAPSE_WHITESPACE, ' ')
     .trim()
 
-  if (options.maxLength === undefined || text.length <= options.maxLength) {
+  const { maxLength } = options
+  if (maxLength === undefined) {
     return text
   }
 
-  return `${text.slice(0, options.maxLength - 1).replace(/\s*\S*$/, '')}…`
+  if (!Number.isInteger(maxLength) || maxLength < 0) {
+    throw new TypeError('markdownToPlainText: maxLength must be a non-negative integer')
+  }
+
+  if (maxLength === 0) {
+    return ''
+  }
+
+  if (text.length <= maxLength) {
+    return text
+  }
+
+  return `${text.slice(0, maxLength - 1).replace(TRAILING_PARTIAL_WORD, '')}…`
 }

--- a/src/lib/spec/createOpenApiSpec.ts
+++ b/src/lib/spec/createOpenApiSpec.ts
@@ -126,12 +126,13 @@ export function createOpenApiSpec(options: {
             if (!paths || !paths[path] || !paths[path][verb]) {
               return null
             }
-            const { operationId, summary, tags } = paths[path][verb]
+            const { operationId, summary, description, tags } = paths[path][verb]
             return {
               path,
               verb,
               operationId,
               summary,
+              description,
               tags: tags ?? [],
             }
           })

--- a/test/composables/usePaths.test.ts
+++ b/test/composables/usePaths.test.ts
@@ -32,6 +32,32 @@ describe('usePaths', () => {
     ])
   })
 
+  it('exposes the operation description', () => {
+    const result = usePaths({
+      spec: {
+        openapi: '3.0.0',
+        paths: {
+          '/users': {
+            get: {
+              operationId: 'getUsers',
+              summary: 'GET /users',
+              description: 'Returns **all** users.',
+            },
+            post: {
+              operationId: 'createUser',
+              summary: 'POST /users',
+            },
+          },
+        },
+      },
+    }).getPathsByVerbs()
+
+    expect(result.map(({ operationId, description }) => ({ operationId, description }))).toEqual([
+      { operationId: 'getUsers', description: 'Returns **all** users.' },
+      { operationId: 'createUser', description: undefined },
+    ])
+  })
+
   it('returns the correct tags', () => {
     const result = paths.getTags()
     expect(result).toEqual([

--- a/test/lib/markdown/markdownToPlainText.test.ts
+++ b/test/lib/markdown/markdownToPlainText.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { markdownToPlainText } from '../../../src/lib/markdown/markdownToPlainText'
+
+describe('markdownToPlainText', () => {
+  it('returns plain sentences unchanged', () => {
+    expect(markdownToPlainText('Returns a list of users.')).toBe('Returns a list of users.')
+  })
+
+  it('strips markdown formatting but keeps the text', () => {
+    expect(markdownToPlainText('Returns **all** `users` for the *current* account.'))
+      .toBe('Returns all users for the current account.')
+  })
+
+  it('keeps link text and drops the URL', () => {
+    expect(markdownToPlainText('See [the guide](https://example.com/guide) for details.'))
+      .toBe('See the guide for details.')
+  })
+
+  it('does not mangle identifiers containing underscores', () => {
+    expect(markdownToPlainText('Filter by `group_id` or snake_case_field.'))
+      .toBe('Filter by group_id or snake_case_field.')
+  })
+
+  it('strips headings and blockquotes', () => {
+    expect(markdownToPlainText('# Overview\n\n> Note: beta endpoint.\n\nReturns users.'))
+      .toBe('Overview Note: beta endpoint. Returns users.')
+  })
+
+  it('strips embedded HTML tags but keeps their text content', () => {
+    expect(markdownToPlainText('Returns users. <span class="badge">Beta</span>'))
+      .toBe('Returns users. Beta')
+  })
+
+  it('collapses newlines and repeated whitespace into single spaces', () => {
+    expect(markdownToPlainText('First line.\n\nSecond   line.'))
+      .toBe('First line. Second line.')
+  })
+
+  it('decodes HTML entities produced by rendering', () => {
+    expect(markdownToPlainText('Filters & sorting, e.g. `a < b`.'))
+      .toBe('Filters & sorting, e.g. a < b.')
+  })
+
+  it('returns an empty string for empty or missing input', () => {
+    expect(markdownToPlainText('')).toBe('')
+    expect(markdownToPlainText(undefined)).toBe('')
+    expect(markdownToPlainText(null)).toBe('')
+  })
+
+  it('truncates at a word boundary when maxLength is set', () => {
+    const result = markdownToPlainText('Returns every user registered in the current account.', { maxLength: 30 })
+    expect(result).toBe('Returns every user…')
+    expect(result.length).toBeLessThanOrEqual(30)
+  })
+
+  it('does not truncate text shorter than maxLength', () => {
+    expect(markdownToPlainText('Returns users.', { maxLength: 30 })).toBe('Returns users.')
+  })
+})

--- a/test/lib/markdown/markdownToPlainText.test.ts
+++ b/test/lib/markdown/markdownToPlainText.test.ts
@@ -31,6 +31,13 @@ describe('markdownToPlainText', () => {
       .toBe('Returns users. Beta')
   })
 
+  it('strips tags whose quoted attributes contain >', () => {
+    expect(markdownToPlainText('Returns users. <span title="x > y">Beta</span>'))
+      .toBe('Returns users. Beta')
+    expect(markdownToPlainText(`Keeps text <span title='a > b'>inside</span> tags.`))
+      .toBe('Keeps text inside tags.')
+  })
+
   it('collapses newlines and repeated whitespace into single spaces', () => {
     expect(markdownToPlainText('First line.\n\nSecond   line.'))
       .toBe('First line. Second line.')
@@ -55,5 +62,15 @@ describe('markdownToPlainText', () => {
 
   it('does not truncate text shorter than maxLength', () => {
     expect(markdownToPlainText('Returns users.', { maxLength: 30 })).toBe('Returns users.')
+  })
+
+  it('returns an empty string when maxLength is 0', () => {
+    expect(markdownToPlainText('Returns users.', { maxLength: 0 })).toBe('')
+  })
+
+  it('rejects invalid maxLength values', () => {
+    expect(() => markdownToPlainText('Returns users.', { maxLength: -1 })).toThrow(TypeError)
+    expect(() => markdownToPlainText('Returns users.', { maxLength: 1.5 })).toThrow(TypeError)
+    expect(() => markdownToPlainText('Returns users.', { maxLength: Number.POSITIVE_INFINITY })).toThrow(TypeError)
   })
 })


### PR DESCRIPTION
# Description

When generating per-operation pages with the documented paths-loader pattern, `getPathsByVerbs()` returns `operationId`, `summary`, `path`, `verb` and `tags`, but drops the operation's `description`. To set a `<meta name="description">` on those pages you have to look the operation up in the spec again and strip the Markdown yourself, which is easy to get wrong (underscores in identifiers, embedded HTML, entities).

This PR:

- adds the operation's raw `description` to the objects returned by `getPathsByVerbs()`
- adds a `markdownToPlainText(markdown, { maxLength })` helper that renders the description with markdown-it (already a dependency) and reduces the result to a single line of plain text, truncated at a word boundary when `maxLength` is set
- documents the pattern in the "Pages by Operation" guide, including the `transformPageData` wiring to get the params onto the page data

We use this on our own VitePress site to generate meta descriptions for API reference pages, and it seemed useful for anyone following the dynamic-pages setup.

All 698 existing tests pass, plus 12 new ones covering the helper and the new field.

## Related issues/external references

None

## Types of changes

- New feature _(non-breaking change which adds functionality)_
- Documentation improvement
